### PR TITLE
Use .Release.Name and .Release.Namespace throughout

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.workbench.resource_name }}
-  namespace: {{ .Values.workbench.namespace }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
 data:
   # Enable TLS (HTTPS)?
   tls.enable: "true"
@@ -12,8 +12,13 @@ data:
   workbench.name: "{{ .Values.workbench.name }}"
   workbench.support_email: "{{ .Values.workbench.support_email }}"
   workbench.analytics_tracking_id: ""
-  workbench.signin_url: "https://workbench.{{ .Values.workbench.domain }}/login/"
-  workbench.auth_url: "https://workbench.{{ .Values.workbench.domain }}/cauth/auth"
+{{ if .Values.oauth.enabled }}
+  workbench.signin_url: "{{ .Values.oauth.signin_url }}"
+  workbench.auth_url: "{{ .Values.oauth.auth_url }}"
+{{ else }}
+  workbench.signin_url: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/login/"
+  workbench.auth_url: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/cauth/auth"
+{{ end }}
 
   # IP address used by DNS service 
   #workbench.ip: ""
@@ -32,8 +37,8 @@ data:
   # FIXME: this is probably insecure, and should likely be using a secret instead
   # If using gmail as your SMTP service, use the following. If using 2-factor
   # auth see https://support.google.com/accounts/answer/185833?hl=en
-  smtp.gmail_user: "{{ .Values.smtp.user }}"
-  smtp.gmail_pass: "{{ .Values.smtp.pass }}"
+  smtp.gmail_user: "{{ .Values.smtp.gmail_user }}"
+  smtp.gmail_pass: "{{ .Values.smtp.gmail_pass }}"
 
   # FIXME: this is probably insecure, and should likely be using a secret instead
   # If using AWS as your SMTP service, use the following

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,19 +1,14 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.workbench.namespace }}
----
 {{ if .Values.rbac.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.workbench.resource_name }}
-  namespace: {{ .Values.workbench.namespace }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.workbench.resource_name }}
+  name: {{ .Release.Name }}
 rules:
 - apiGroups: ["", "extensions", "apps", "batch", "policy", "rbac.authorization.k8s.io"]
   resources: ["componentstatuses", "persistentvolumeclaims", "replicasets", "deployments", "events", "endpoints", "pods", "pods/log", "namespaces", "services", "replicationcontrollers", "secrets", "resourcequotas", "limitranges"]
@@ -31,27 +26,27 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.workbench.resource_name }}
+  name: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.workbench.resource_name }}
-  namespace: {{ .Values.workbench.namespace }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.workbench.resource_name }}
+  name: {{ .Release.Name }}
   apiGroup: rbac.authorization.k8s.io
 ---
 {{ end }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.workbench.resource_name }}
-  namespace: {{ .Values.workbench.namespace }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
   labels:
-    component: {{ .Values.workbench.resource_name }}
+    component: {{ .Release.Name }}
 spec:
   selector:
-    component: {{ .Values.workbench.resource_name }}
+    component: {{ .Release.Name }}
   ports:
     - port: 80
       name: webui
@@ -67,8 +62,8 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Values.workbench.resource_name }}-auth
-  namespace: {{ .Values.workbench.namespace }}
+  name: {{ .Release.Name }}-auth
+  namespace: {{ .Release.Namespace }}
   annotations:
     "nginx.ingress.kubernetes.io/auth-url": "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/cauth/auth"
     "nginx.ingress.kubernetes.io/auth-signin": "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/login/"
@@ -85,18 +80,18 @@ spec:
       paths:
       - path: /logs
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /dashboard
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Values.workbench.resource_name }}-open
-  namespace: {{ .Values.workbench.namespace }}
+  name: {{ .Release.Name }}-open
+  namespace: {{ .Release.Namespace }}
   annotations:
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
     "nginx.ingress.kubernetes.io/force-ssl-redirect": "true"
@@ -111,64 +106,64 @@ spec:
       paths:
       - path: /api
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 30001
       - path: /login
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /landing
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /dashboard
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /cauth
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /shared
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /bower_components
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /node_modules
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /asset
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /ConfigModule.js
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ .Values.workbench.resource_name }}
-  namespace: {{ .Values.workbench.namespace }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      component: {{ .Values.workbench.resource_name }}
+      component: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        component: {{ .Values.workbench.resource_name }}
+        component: {{ .Release.Name }}
     spec:
 {{ if .Values.rbac.enabled }}
-      serviceAccountName: {{ .Values.workbench.resource_name }}
+      serviceAccountName: {{ .Release.Name }}
 {{ end }}
       volumes:
        - hostPath:
@@ -177,10 +172,20 @@ spec:
        - hostPath:
             path: "{{ .Values.workbench.etcd_path }}"
          name: varetcd
+{{ if .Values.workbench.dev.enabled | default false }}
+       - hostPath:
+            path: "{{ .Values.workbench.dev.uisrc }}"
+         name: uisrc
+{{ end }}
       containers:
       - name: webui
         image: {{ required "Must specify an image for ndslabs-webui" .Values.workbench.images.webui }}
         imagePullPolicy: Always
+{{ if .Values.workbench.dev.enabled | default false }}
+        volumeMounts: 
+        - name: uisrc
+          mountPath: "/home"
+{{ end }}
         ports:
         - containerPort: 3000
           protocol: TCP
@@ -188,27 +193,27 @@ spec:
           - name: DOMAIN
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.domain
           - name: APISERVER_SECURE
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: tls.enable
           - name: SIGNIN_URL
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.signin_url
           - name: ANALYTICS_ACCOUNT
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.analytics_tracking_id
           - name: SUPPORT_EMAIL
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.support_email
           - name: APISERVER_HOST
             value: "{{ .Values.workbench.subdomain_prefix }}.$(DOMAIN)"
@@ -245,37 +250,37 @@ spec:
           - name: SUPPORT_EMAIL
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.support_email
           - name: REQUIRE_APPROVAL
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.require_account_approval
           - name: DOMAIN
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.domain
           - name: SPEC_GIT_REPO
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: git.spec_repo
           - name: SPEC_GIT_BRANCH
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: git.spec_branch
           - name: SIGNIN_URL
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.signin_url
           - name: AUTH_URL
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.auth_url
           - name: CORS_ORIGIN_ADDR
             value: "https://{{ .Values.workbench.subdomain_prefix }}.$(DOMAIN)"
@@ -317,50 +322,50 @@ spec:
           - name: MAILNAME
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.host
           - name: PORT
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.port
           - name: GMAIL_USER
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.gmail_user
           - name: GMAIL_PASSWORD
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.gmail_pass
           - name: SES_USER
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.aws_ses_user
           - name: SES_PASSWORD
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.aws_ses_password
           - name: SMARTHOST_ADDRESS
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.smarthost_address
           - name: SMARTHOST_PORT
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.smarthost_port
           - name: SMARTHOST_USER
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.smarthost_user
           - name: SMARTHOST_PASSWORD
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.smarthost_password

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -5,5 +5,5 @@ data:
 kind: Secret
 metadata:
   name: {{ .Values.tls.secretName }}
-  namespace: {{ .Values.workbench.namespace }}
+  namespace: {{ .Release.Namespace }}
 type: Opaque

--- a/values.yaml
+++ b/values.yaml
@@ -3,8 +3,9 @@
 # Declare variables to be passed into your templates.
 
 workbench:
-  namespace: "workbench"
-  resource_name: "ndslabs-workbench"
+  dev:
+    enabled: false
+    uisrc: ""
   name: "Labs Workbench"
   domain: "local.ndslabs.org"
   subdomain_prefix: "www"


### PR DESCRIPTION
Changes:
* Replaced `.Values.workbench.resource_name` with `.Release.Name` throughout
* Replaced `.Values.workbench.namespace` with `.Release.Namespace` throughout
* Abstracted `signin_url` / `auth_url` out to `values.yaml`
* Added optional `.Values.workbench.dev.enabled` / `.Values.workbench.dev.uisrc` flags for mapping the UI source code into the Workbench pod