### PR TITLE
Support --name and --namespace in Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Clone this repo locally (somewhere with `kubectl` access and the `helm` client i
 ubuntu@lambert8-dev:~$ git clone https://github.com/nds-org/workbench-helm-chart && cd workbench-helm-chart/
 ```
 
-Generate a self-signed certificate:
+Have a valid, signed certificate, or you can generate a self-signed certificate:
 ```bash
 ubuntu@lambert8-dev:~/workbench-helm-chart$ ./generate-self-signed-cert.sh example.com
 
@@ -37,10 +37,10 @@ vi values.yaml
 
 Deploy the helm chart:
 ```bash
-ubuntu@lambert8-dev:~/workbench-helm-chart$ helm install .
-NAME:   joking-greyhound
+ubuntu@lambert8-dev:~/workbench-helm-chart$ helm install . --name=workbench --namespace=workbench
+NAME:   workbench
 LAST DEPLOYED: Fri Jun 29 23:48:48 2018
-NAMESPACE: default
+NAMESPACE: workbench
 STATUS: DEPLOYED
 
 RESOURCES:
@@ -93,21 +93,21 @@ You can run `helm list` to view the status of your Helm deployment:
 ```bash
 ubuntu@lambert8-dev:~/workbench-helm-chart$ helm list
 NAME            	REVISION	UPDATED                 	STATUS  	CHART          	NAMESPACE
-joking-greyhound	1       	Sat Jun 30 04:39:35 2018	DEPLOYED	workbench-1.1.0	default  
+workbench		1       	Sat Jun 30 04:39:35 2018	DEPLOYED	workbench-1.1.0	workbench
 support         	1       	Fri Jun 29 22:29:34 2018	DEPLOYED	support-0.1.0  	support  
 ```
 
 # Modifying your Parameters
 If you need to change your instance parameters, simply modify `values.yaml` and run `helm upgrade <release-name> .`
 
-The `<release-name>` can be discovered using the `helm list` command, shown above.
+The `<release-name>` can be discovered using the `helm list` command, shown above. You can override this by passing `--name=<release-name>` to `helm install`
 
 This will perform a rolling upgrade on your chart's resources to use the newest values:
 ```bash
-ubuntu@lambert8-dev:~/workbench-helm-chart$ helm upgrade joking-greyhound .
-Release "joking-greyhound" has been upgraded. Happy Helming!
+ubuntu@lambert8-dev:~/workbench-helm-chart$ helm upgrade workbench .
+Release "workbench" has been upgraded. Happy Helming!
 LAST DEPLOYED: Sat Jun 30 04:39:35 2018
-NAMESPACE: default
+NAMESPACE: workbench
 STATUS: DEPLOYED
 
 RESOURCES:
@@ -154,18 +154,18 @@ ndslabs-workbench  ClusterIP  10.109.18.61  <none>       80/TCP,30001/TCP,25/TCP
 # Shutting it Down
 To clean up all resources used by Labs Workbench, simply run `helm delete <release-name>`
 
-The `<release-name>` can be discovered using the `helm list` command, shown above.
+The `<release-name>` can be discovered using the `helm list` command, shown above. You can override this by passing `--name=<release-name>` to `helm install`
 
 This will tear down and remove all resources installed by this Helm chart:
 ```bash
-ubuntu@lambert8-dev:~/workbench-helm-chart$ helm delete joking-greyhound
-release "joking-greyhound" deleted
+ubuntu@lambert8-dev:~/workbench-helm-chart$ helm delete workbench
+release "workbench" deleted
 ```
 
 NOTE: This does not currently clean up or delete any user namespace or deployments.
 
 # TODO
-* Figure out how to correctly set the namespace listed by `helm list` (helm always lists "default" for some reason)
+* Improve hosting/workflow - user should not have to clone this repo to install via Helm
 * NFS / PVC vs hostPath option?
 * OAuth vs custom auth option?
 * Ingress Controller vs NodePort option?

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Clone this repo locally (somewhere with `kubectl` access and the `helm` client i
 ubuntu@lambert8-dev:~$ git clone https://github.com/nds-org/workbench-helm-chart && cd workbench-helm-chart/
 ```
 
-Have a valid, signed certificate, or you can generate a self-signed certificate:
+Have a [valid/signed TLS certificate](https://letsencrypt.org/), or you can generate a self-signed certificate:
 ```bash
 ubuntu@lambert8-dev:~/workbench-helm-chart$ ./generate-self-signed-cert.sh example.com
 
@@ -31,7 +31,7 @@ vi values.yaml
 ```
 
 * NOTE 1: Be sure to set correct values for your `domain` and `support_email` in `values.yaml`.
-* NOTE 2: Be sure to copy and paste the contents of your self-signed cert/key into the appropriate variables in `values.yaml`.
+* NOTE 2: Be sure to copy and paste the contents of your TLS cert/key into the appropriate variables in `values.yaml`.
 * NOTE 3: If you are using Kubernetes >= 1.8, you will likely need to enable RBAC in `values.yaml`.
 * NOTE 4: If you do not specify an SMTP configurations, some environments may allow you to fall back to the default SMTP server (e.g. Nebula, SDSC, etc).
 

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.workbench.resource_name }}
-  namespace: {{ .Values.workbench.namespace }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
 data:
   # Enable TLS (HTTPS)?
   tls.enable: "true"
@@ -12,8 +12,13 @@ data:
   workbench.name: "{{ .Values.workbench.name }}"
   workbench.support_email: "{{ .Values.workbench.support_email }}"
   workbench.analytics_tracking_id: ""
+{{ if .Values.oauth.enabled }}
+  workbench.signin_url: "{{ .Values.oauth.signin_url }}"
+  workbench.auth_url: "{{ .Values.oauth.auth_url }}"
+{{ else }}
   workbench.signin_url: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/login/"
   workbench.auth_url: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/cauth/auth"
+{{ end }}
 
   # IP address used by DNS service 
   #workbench.ip: ""
@@ -32,8 +37,8 @@ data:
   # FIXME: this is probably insecure, and should likely be using a secret instead
   # If using gmail as your SMTP service, use the following. If using 2-factor
   # auth see https://support.google.com/accounts/answer/185833?hl=en
-  smtp.gmail_user: "{{ .Values.smtp.user }}"
-  smtp.gmail_pass: "{{ .Values.smtp.pass }}"
+  smtp.gmail_user: "{{ .Values.smtp.gmail_user }}"
+  smtp.gmail_pass: "{{ .Values.smtp.gmail_pass }}"
 
   # FIXME: this is probably insecure, and should likely be using a secret instead
   # If using AWS as your SMTP service, use the following

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -12,8 +12,8 @@ data:
   workbench.name: "{{ .Values.workbench.name }}"
   workbench.support_email: "{{ .Values.workbench.support_email }}"
   workbench.analytics_tracking_id: ""
-  workbench.signin_url: "https://workbench.{{ .Values.workbench.domain }}/login/"
-  workbench.auth_url: "https://workbench.{{ .Values.workbench.domain }}/cauth/auth"
+  workbench.signin_url: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/login/"
+  workbench.auth_url: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/cauth/auth"
 
   # IP address used by DNS service 
   #workbench.ip: ""

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -146,6 +146,29 @@ spec:
           servicePort: 80
 ---
 apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/landing/"
+  name: {{ .Release.Name }}-root
+  namespace: {{ .Release.Namespace }}
+spec:
+  rules:
+  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ .Release.Name }}
+          servicePort: 80
+        path: /
+  tls:
+  - hosts:
+    - {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}
+    secretName: {{ .Values.tls.secretName }}
+---
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -172,10 +172,20 @@ spec:
        - hostPath:
             path: "{{ .Values.workbench.etcd_path }}"
          name: varetcd
+{{ if .Values.workbench.dev.enabled | default false }}
+       - hostPath:
+            path: "{{ .Values.workbench.dev.uisrc }}"
+         name: uisrc
+{{ end }}
       containers:
       - name: webui
         image: {{ required "Must specify an image for ndslabs-webui" .Values.workbench.images.webui }}
         imagePullPolicy: Always
+{{ if .Values.workbench.dev.enabled | default false }}
+        volumeMounts: 
+        - name: uisrc
+          mountPath: "/home"
+{{ end }}
         ports:
         - containerPort: 3000
           protocol: TCP

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.workbench.namespace }}
----
 {{ if .Values.rbac.enabled }}
 apiVersion: v1
 kind: ServiceAccount

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.workbench.resource_name }}
-  namespace: {{ .Values.workbench.namespace }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.workbench.resource_name }}
+  name: {{ .Release.Name }}
 rules:
 - apiGroups: ["", "extensions", "apps", "batch", "policy", "rbac.authorization.k8s.io"]
   resources: ["componentstatuses", "persistentvolumeclaims", "replicasets", "deployments", "events", "endpoints", "pods", "pods/log", "namespaces", "services", "replicationcontrollers", "secrets", "resourcequotas", "limitranges"]
@@ -26,27 +26,27 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.workbench.resource_name }}
+  name: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.workbench.resource_name }}
-  namespace: {{ .Values.workbench.namespace }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.workbench.resource_name }}
+  name: {{ .Release.Name }}
   apiGroup: rbac.authorization.k8s.io
 ---
 {{ end }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.workbench.resource_name }}
-  namespace: {{ .Values.workbench.namespace }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
   labels:
-    component: {{ .Values.workbench.resource_name }}
+    component: {{ .Release.Name }}
 spec:
   selector:
-    component: {{ .Values.workbench.resource_name }}
+    component: {{ .Release.Name }}
   ports:
     - port: 80
       name: webui
@@ -62,8 +62,8 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Values.workbench.resource_name }}-auth
-  namespace: {{ .Values.workbench.namespace }}
+  name: {{ .Release.Name }}-auth
+  namespace: {{ .Release.Namespace }}
   annotations:
     "nginx.ingress.kubernetes.io/auth-url": "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/cauth/auth"
     "nginx.ingress.kubernetes.io/auth-signin": "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/login/"
@@ -80,18 +80,18 @@ spec:
       paths:
       - path: /logs
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /dashboard
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Values.workbench.resource_name }}-open
-  namespace: {{ .Values.workbench.namespace }}
+  name: {{ .Release.Name }}-open
+  namespace: {{ .Release.Namespace }}
   annotations:
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
     "nginx.ingress.kubernetes.io/force-ssl-redirect": "true"
@@ -106,64 +106,64 @@ spec:
       paths:
       - path: /api
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 30001
       - path: /login
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /landing
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /dashboard
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /cauth
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /shared
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /bower_components
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /node_modules
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /asset
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
       - path: /ConfigModule.js
         backend:
-          serviceName: {{ .Values.workbench.resource_name }}
+          serviceName: {{ .Release.Name }}
           servicePort: 80
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ .Values.workbench.resource_name }}
-  namespace: {{ .Values.workbench.namespace }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      component: {{ .Values.workbench.resource_name }}
+      component: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        component: {{ .Values.workbench.resource_name }}
+        component: {{ .Release.Name }}
     spec:
 {{ if .Values.rbac.enabled }}
-      serviceAccountName: {{ .Values.workbench.resource_name }}
+      serviceAccountName: {{ .Release.Name }}
 {{ end }}
       volumes:
        - hostPath:
@@ -183,27 +183,27 @@ spec:
           - name: DOMAIN
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.domain
           - name: APISERVER_SECURE
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: tls.enable
           - name: SIGNIN_URL
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.signin_url
           - name: ANALYTICS_ACCOUNT
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.analytics_tracking_id
           - name: SUPPORT_EMAIL
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.support_email
           - name: APISERVER_HOST
             value: "{{ .Values.workbench.subdomain_prefix }}.$(DOMAIN)"
@@ -240,37 +240,37 @@ spec:
           - name: SUPPORT_EMAIL
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.support_email
           - name: REQUIRE_APPROVAL
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.require_account_approval
           - name: DOMAIN
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.domain
           - name: SPEC_GIT_REPO
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: git.spec_repo
           - name: SPEC_GIT_BRANCH
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: git.spec_branch
           - name: SIGNIN_URL
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.signin_url
           - name: AUTH_URL
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: workbench.auth_url
           - name: CORS_ORIGIN_ADDR
             value: "https://{{ .Values.workbench.subdomain_prefix }}.$(DOMAIN)"
@@ -312,50 +312,50 @@ spec:
           - name: MAILNAME
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.host
           - name: PORT
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.port
           - name: GMAIL_USER
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.gmail_user
           - name: GMAIL_PASSWORD
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.gmail_pass
           - name: SES_USER
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.aws_ses_user
           - name: SES_PASSWORD
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.aws_ses_password
           - name: SMARTHOST_ADDRESS
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.smarthost_address
           - name: SMARTHOST_PORT
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.smarthost_port
           - name: SMARTHOST_USER
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.smarthost_user
           - name: SMARTHOST_PASSWORD
             valueFrom:
               configMapKeyRef:
-                name: {{ .Values.workbench.resource_name }}
+                name: {{ .Release.Name }}
                 key: smtp.smarthost_password

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -5,5 +5,5 @@ data:
 kind: Secret
 metadata:
   name: {{ .Values.tls.secretName }}
-  namespace: {{ .Values.workbench.namespace }}
+  namespace: {{ .Release.Namespace }}
 type: Opaque

--- a/values.yaml
+++ b/values.yaml
@@ -3,8 +3,6 @@
 # Declare variables to be passed into your templates.
 
 workbench:
-  namespace: "workbench"
-  resource_name: "ndslabs-workbench"
   name: "Labs Workbench"
   domain: "local.ndslabs.org"
   subdomain_prefix: "www"

--- a/values.yaml
+++ b/values.yaml
@@ -3,6 +3,9 @@
 # Declare variables to be passed into your templates.
 
 workbench:
+  dev:
+    enabled: false
+    uisrc: ""
   name: "Labs Workbench"
   domain: "local.ndslabs.org"
   subdomain_prefix: "www"
@@ -20,6 +23,12 @@ workbench:
     etcd: "ndslabs/etcd:2.2.5"
     smtp: "namshi/smtp:latest"
   
+# FIXME: This has not been tested
+oauth:
+  enabled: false
+  signin_url: ""
+  auth_url: ""
+
 rbac:
   enabled: true
 


### PR DESCRIPTION
Fixes https://github.com/nds-org/ndslabs/issues/252

Changes:
* Removed explicit creation of a Namespace resource, as this caused a conflict in Helm
* Removed `.Values.workbench.resource_name` and `.Values.workbench.namespace`
* Adjusted templates to respect `.Release.Name` and `.Release.Namespace`
* Adjusted ingress rules / config map to respect `.Values.workbench.subdomain_prefix`
* Abstracted `signin_url` / `auth_url` out to values.yaml, hide these behind a `.Values.oauth.enabled` flag
* Added optional `.Values.workbench.dev.enabled` / `.Values.workbench.dev.uisrc` flags for mapping the UI source code into the Workbench pod
* Added a new ingress rule to redirect `/` -> `/landing/`