### PR TITLE
Added nodeSelector configuration options to chart.

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -12,6 +12,8 @@ data:
   workbench.name: "{{ .Values.workbench.name }}"
   workbench.support_email: "{{ .Values.workbench.support_email }}"
   workbench.analytics_tracking_id: ""
+  workbench.node_selector_name: "{{ .Values.workbench.node_selector_name }}"
+  workbench.node_selector_value: "{{ .Values.workbench.node_selector_value }}"
 {{ if .Values.oauth.enabled }}
   workbench.signin_url: "{{ .Values.oauth.signin_url }}"
   workbench.auth_url: "{{ .Values.oauth.auth_url }}"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -305,6 +305,16 @@ spec:
               configMapKeyRef:
                 name: {{ .Release.Name }}
                 key: workbench.auth_url
+          - name: NODE_SELECTOR_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.node_selector_name
+          - name: NODE_SELECTOR_VALUE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.node_selector_value
           - name: CORS_ORIGIN_ADDR
             value: "https://{{ .Values.workbench.subdomain_prefix }}.$(DOMAIN)"
           - name: ETCD_ADDR


### PR DESCRIPTION
## Problem
Adds nodeSelector configuration to Helm chart (related to https://github.com/nds-org/ndslabs/pull/257)

## Approach
Update `ConfigMap` and `Deployment` to support optional `node_selector_name` and `node_selector_value` options.

## How to Test
Requires  https://github.com/nds-org/ndslabs/pull/257

1. Clone / checkout this branch and deploy the Helm chart
1. Register / login to your instance
1. Start the File Manager. File Manager should start without error. Optionally, confirm no nodeselector configured via `kubectl describe pod -n namespace podname`
1. Stop the File Manager
1. Edit `values.yaml` and add the following lines under the `workbench` header:
```
   node_selector_name: "test"
   node_selector_value: "true"
```
1. Upgrade the Helm chart with the new config
1. Start the File Manager. File Manager should fail (no nodes match selector)
1. Add the label `kubectl label node <node> test=true`
1. Restart the File Manager. File Manager should start without error.