### PR TITLE
Enable deployment on GKE

### DIFF
--- a/nfs-example/README.md
+++ b/nfs-example/README.md
@@ -1,0 +1,35 @@
+# ReadWriteMany NFS provisioner
+
+
+From [Google Container Engine docs](https://cloud.google.com/container-engine/docs/role-based-access-control):
+
+>  Because of the way Container Engine checks permissions when you create a 
+> Role or ClusterRole, you must first create a RoleBinding that grants you 
+> all of the permissions included in the role you want to create.
+> An example workaround is to create a RoleBinding that gives your 
+> Google identity a cluster-admin role before attempting to create 
+> additional Role or ClusterRole permissions. 
+
+
+Get your `gcloud` identity:
+```
+$ gcloud info | grep Account
+Account: [myname@example.org]
+```
+
+Create  the cluster role binding:
+```
+kubectl create clusterrolebinding myname-cluster-admin-binding --clusterrole=cluster-admin --user=myname@example.org
+```
+
+Create the NFS provisioner (backed by GCE Disk):
+```
+kubectl create -f deployment.yaml -f rbac.yaml -f class.yaml
+```
+
+To test:
+```
+kubectl create -f test.yaml
+kubectl exec busybox1 -c "echo test >> /test/x"
+kubectl exec <nfs-provisioner> -- bash -c "cat /export/pvc*/x"
+```

--- a/nfs-example/class.yaml
+++ b/nfs-example/class.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: nfs
+provisioner: ndslabs.org/nfs
+mountOptions:
+  - vers=4.1

--- a/nfs-example/deployment.yaml
+++ b/nfs-example/deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-server
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfs-provisioner
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: nfs-provisioner
+  labels:
+    app: nfs-provisioner
+spec:
+  ports:
+    - name: nfs
+      port: 2049
+    - name: mountd
+      port: 20048
+    - name: rpcbind
+      port: 111
+    - name: rpcbind-udp
+      port: 111
+      protocol: UDP
+  selector:
+    app: nfs-provisioner
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: nfs-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: nfs-provisioner
+  replicas: 1
+  strategy:
+    type: Recreate 
+  template:
+    metadata:
+      labels:
+        app: nfs-provisioner
+    spec:
+      serviceAccount: nfs-provisioner
+      containers:
+        - name: nfs-provisioner
+          image: quay.io/kubernetes_incubator/nfs-provisioner:latest
+          ports:
+            - name: nfs
+              containerPort: 2049
+            - name: mountd
+              containerPort: 20048
+            - name: rpcbind
+              containerPort: 111
+            - name: rpcbind-udp
+              containerPort: 111
+              protocol: UDP
+          securityContext:
+            capabilities:
+              add:
+                - DAC_READ_SEARCH
+                - SYS_RESOURCE
+          args:
+            - "-provisioner=ndslabs.org/nfs"
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SERVICE_NAME
+              value: nfs-provisioner
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: export-volume
+              mountPath: /export
+      volumes:
+        - name: export-volume
+          persistentVolumeClaim:
+            claimName: nfs-server

--- a/nfs-example/rbac.yaml
+++ b/nfs-example/rbac.yaml
@@ -1,0 +1,61 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nfs-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services", "endpoints"]
+    verbs: ["get"]
+  - apiGroups: ["extensions"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["nfs-provisioner"]
+    verbs: ["use"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: run-nfs-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: nfs-provisioner
+     # replace with namespace where provisioner is deployed
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: nfs-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: leader-locking-nfs-provisioner
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: leader-locking-nfs-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: nfs-provisioner
+    # replace with namespace where provisioner is deployed
+    namespace: default
+roleRef:
+  kind: Role
+  name: leader-locking-nfs-provisioner
+  apiGroup: rbac.authorization.k8s.io

--- a/nfs-example/test.yaml
+++ b/nfs-example/test.yaml
@@ -1,0 +1,32 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: test-claim
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "nfs"
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Mi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox1
+  namespace: default
+spec:
+  containers:
+  - image: busybox
+    command:
+      - sleep
+      - "3600"
+    volumeMounts:
+    - name: glfs
+      mountPath: /test
+    name: busybox
+  volumes:
+  - name: glfs
+    persistentVolumeClaim:
+      claimName: test-claim

--- a/rbac-config.yaml
+++ b/rbac-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -19,6 +19,8 @@ data:
   workbench.signin_url: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/login/"
   workbench.auth_url: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/cauth/auth"
 {{ end }}
+  workbench.home_storage.home_pvc_suffix: "{{ .Values.workbench.home_storage.home_pvc_suffix }}"
+  workbench.home_storage.pvc_storage_class: "{{ .Values.workbench.home_storage.pvc_storage_class }}"
 
   # IP address used by DNS service 
   #workbench.ip: ""

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -21,6 +21,8 @@ data:
 {{ end }}
   workbench.home_storage.home_pvc_suffix: "{{ .Values.workbench.home_storage.home_pvc_suffix }}"
   workbench.home_storage.pvc_storage_class: "{{ .Values.workbench.home_storage.pvc_storage_class }}"
+  workbench.timeout: "{{ .Values.workbench.timeout }}"
+  workbench.inactivity_timeout: "{{ .Values.workbench.inactivity_timeout }}"
 
   # IP address used by DNS service 
   #workbench.ip: ""

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -338,7 +338,7 @@ spec:
         image: {{ required "Must specify an image for ndslabs-etcd" .Values.workbench.images.etcd }}
         command:
         - /usr/local/bin/etcd
-        - --bind-addr=0.0.0.0:4001
+        - --listen-client-urls=http://0.0.0.0:4001
         - --advertise-client-urls=http://127.0.0.1:4001
         - --data-dir=/var/etcd/data
         ports:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -65,6 +65,7 @@ metadata:
   name: {{ .Release.Name }}-auth
   namespace: {{ .Release.Namespace }}
   annotations:
+    "kubernetes.io/ingress.class": "nginx"
     "nginx.ingress.kubernetes.io/auth-url": "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/cauth/auth"
     "nginx.ingress.kubernetes.io/auth-signin": "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/login/"
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
@@ -93,6 +94,7 @@ metadata:
   name: {{ .Release.Name }}-open
   namespace: {{ .Release.Namespace }}
   annotations:
+    "kubernetes.io/ingress.class": "nginx"
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
     "nginx.ingress.kubernetes.io/force-ssl-redirect": "true"
 spec:
@@ -149,6 +151,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
+    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/landing/"
@@ -276,6 +279,8 @@ spec:
         - containerPort: 30002
           protocol: TCP
         env:
+          - name: SHARED_VOLUME_PATH
+            value: "/tmp/shared"
           - name: STORAGE_CLASS
             value: "{{ .Values.workbench.persistence.storageClass }}"
           - name: SUPPORT_EMAIL

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -10,8 +10,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}
 rules:
-- apiGroups: ["", "extensions", "apps", "batch", "policy", "rbac.authorization.k8s.io"]
-  resources: ["componentstatuses", "persistentvolumeclaims", "replicasets", "deployments", "events", "endpoints", "pods", "pods/log", "namespaces", "services", "replicationcontrollers", "secrets", "resourcequotas", "limitranges"]
+- apiGroups: ["", "extensions", "apps", "batch", "policy", "rbac.authorization.k8s.io", "networking.k8s.io"]
+  resources: ["componentstatuses", "persistentvolumeclaims", "replicasets", "deployments", "events", "endpoints", "pods", "pods/log", "namespaces", "services", "replicationcontrollers", "secrets", "resourcequotas", "limitranges", "networkpolicies"]
   verbs: ["get", "list", "watch", "update", "patch", "create", "delete"]
 - apiGroups: [""]
   resources: ["configmaps"]

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ .Release.Name }}
 rules:
 - apiGroups: ["", "extensions", "apps", "batch", "policy", "rbac.authorization.k8s.io", "networking.k8s.io"]
-  resources: ["componentstatuses", "persistentvolumeclaims", "replicasets", "deployments", "events", "endpoints", "pods", "pods/log", "namespaces", "services", "replicationcontrollers", "secrets", "resourcequotas", "limitranges", "networkpolicies"]
+  resources: ["componentstatuses", "persistentvolumeclaims", "replicasets", "deployments", "events", "endpoints", "pods", "pods/log", "pods/exec", "namespaces", "services", "replicationcontrollers", "secrets", "resourcequotas", "limitranges", "networkpolicies"]
   verbs: ["get", "list", "watch", "update", "patch", "create", "delete"]
 - apiGroups: [""]
   resources: ["configmaps"]

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -170,6 +170,30 @@ spec:
   - hosts:
     - {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}
     secretName: {{ .Values.tls.secretName }}
+{{- if .Values.workbench.etcd_storage.persistent.type | default false }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Release.Name }}-etcd
+spec:
+  storageClassName: ""
+  capacity:
+    storage: {{ .Values.workbench.etcd_storage.size | quote }}
+  accessModes:
+    - {{ .Values.workbench.etcd_storage.access_mode | quote }}
+  {{- if eq .Values.workbench.etcd_storage.persistent.type "aws" | default nil }}
+  awsElasticBlockStore:
+    volumeID: {{ .Values.workbench.etcd_storage.persistent.volume_id | quote }}
+  {{- else if eq .Values.workbench.etcd_storage.persistent.type "gce" | default nil }}
+  gcePersistentDisk:
+    pdName: {{ .Values.workbench.etcd_storage.persistent.volume_id | quote }}
+  {{- end }}
+    fsType: ext4
+  claimRef:
+    namespace: {{ .Release.Namespace }}
+    name: {{ .Release.Name }}-etcd
+{{- end }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -177,15 +201,19 @@ metadata:
   name: {{ .Release.Name }}-etcd
   namespace: {{ .Release.Namespace }}
   annotations:
-  {{- if .Values.workbench.persistence.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.workbench.persistence.storageClass | quote }}
+  {{- if .Values.workbench.etcd_storage.storage_class }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.workbench.etcd_storage.storage_class | quote }}
   {{- end }}
 spec:
+  {{- if .Values.workbench.etcd_storage.persistent.type | default false }}
+  storageClassName: ""
+  volumeName: {{ .Release.Name }}-etcd
+  {{- end }}
   accessModes:
-    - {{ .Values.workbench.persistence.accessMode | quote }}
+    - {{ .Values.workbench.etcd_storage.access_mode | quote }}
   resources:
     requests:
-      storage: {{ .Values.workbench.persistence.size | quote }}
+      storage: {{ .Values.workbench.etcd_storage.size | quote }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -281,8 +309,6 @@ spec:
         env:
           - name: SHARED_VOLUME_PATH
             value: "/tmp/shared"
-          - name: STORAGE_CLASS
-            value: "{{ .Values.workbench.persistence.storageClass }}"
           - name: SUPPORT_EMAIL
             valueFrom:
               configMapKeyRef:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -326,8 +326,16 @@ spec:
             value: "https://$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT_HTTPS)"
           - name: INGRESS
             value: "LoadBalancer"
-          - name: SERVICE_TIMEOUT
-            value: "10"
+          - name: TIMEOUT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.timeout
+          - name: INACTIVITY_TIMEOUT
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.inactivity_timeout
           - name: TOKEN_PATH
             value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
           - name: SMTP_HOST

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -334,6 +334,16 @@ spec:
             value: "localhost"
           - name: SMTP_TLS
             value: "false"
+          - name: HOME_PVC_SUFFIX
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.home_storage.home_pvc_suffix
+          - name: PVC_STORAGE_CLASS
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.home_storage.pvc_storage_class
       - name: etcd
         image: {{ required "Must specify an image for ndslabs-etcd" .Values.workbench.images.etcd }}
         command:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -168,6 +168,22 @@ spec:
     - {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}
     secretName: {{ .Values.tls.secretName }}
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-etcd
+  namespace: {{ .Release.Namespace }}
+  annotations:
+  {{- if .Values.workbench.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.workbench.persistence.storageClass | quote }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.workbench.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.workbench.persistence.size | quote }}
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -189,11 +205,8 @@ spec:
       serviceAccountName: {{ .Release.Name }}
 {{ end }}
       volumes:
-       - hostPath:
-            path: "{{ .Values.workbench.volume_path }}"
-         name: volumes
-       - hostPath:
-            path: "{{ .Values.workbench.etcd_path }}"
+       - persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-etcd
          name: varetcd
 {{ if .Values.workbench.dev.enabled | default false }}
        - hostPath:
@@ -240,8 +253,8 @@ spec:
                 key: workbench.support_email
           - name: APISERVER_HOST
             value: "{{ .Values.workbench.subdomain_prefix }}.$(DOMAIN)"
-          - name: APISERVER_PORT
-            value: ""
+          - name: NDSLABS_APISERVER_SERVICE_PORT
+            value: "30001"
           - name: APISERVER_PATH
             value: "/api"
         readinessProbe:
@@ -262,14 +275,9 @@ spec:
           protocol: TCP
         - containerPort: 30002
           protocol: TCP
-        volumeMounts:
-          - name: volumes
-            mountPath: "{{ .Values.workbench.volume_path }}"
         env:
-          - name: VOLUME_NAME
-            value: "{{ .Values.workbench.volume_name }}"
-          - name: VOLUME_PATH
-            value: "{{ .Values.workbench.volume_path }}"
+          - name: STORAGE_CLASS
+            value: "{{ .Values.workbench.persistence.storageClass }}"
           - name: SUPPORT_EMAIL
             valueFrom:
               configMapKeyRef:

--- a/values.yaml
+++ b/values.yaml
@@ -18,7 +18,7 @@ workbench:
   images:
     webui: "ndslabs/angular-ui:develop"
     apiserver: "ndslabs/apiserver:develop"
-    etcd: "ndslabs/etcd:2.2.5"
+    etcd: "quay.io/coreos/etcd:v3.3"
     smtp: "namshi/smtp:latest"
   persistence:
     accessMode: "ReadWriteOnce"

--- a/values.yaml
+++ b/values.yaml
@@ -10,18 +10,18 @@ workbench:
   domain: "local.ndslabs.org"
   subdomain_prefix: "www"
   volume_name: "global"
-  support_email: "ndslabs-support@nationaldataservice.org"
+  support_email: "you@email.org"
   require_account_approval: true
   specs:
     repo: "https://github.com/nds-org/ndslabs-specs.git"
     branch: "master"
   images:
-    webui: "ndslabs/angular-ui:1.1.0"
-    apiserver: "ndslabs/apiserver:1.1.0"
+    webui: "ndslabs/angular-ui:develop"
+    apiserver: "ndslabs/apiserver:develop"
     etcd: "ndslabs/etcd:2.2.5"
     smtp: "namshi/smtp:latest"
   persistence:
-    accessMode: "ReadWriteMany"
+    accessMode: "ReadWriteOnce"
     size: "1Gi"
   
 # FIXME: This has not been tested
@@ -38,8 +38,8 @@ smtp:
   host: 
   port: 
   # Specify user/pass to use Gmail SMTP
-  user: 
-  pass: 
+  gmail_user: 
+  gmail_pass: 
 
 # Insert your tls certificate and private key here
 # NOTE: To generate a new certificate, you can run the helper script included with this chart:
@@ -50,13 +50,10 @@ tls:
   secretName: "ndslabs-tls-secret"
   cert: |
     -----BEGIN CERTIFICATE-----
-    PASTE CERTIFICATE CONTENTS HERE
     -----END CERTIFICATE-----
-
   key: |
-    -----BEGIN RSA PRIVATE KEY-----
-    PASTE PRIVATE KEY CONTENTS HERE
-    -----END RSA PRIVATE KEY-----
+    -----BEGIN PRIVATE KEY-----
+    -----END PRIVATE KEY-----
     
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/values.yaml
+++ b/values.yaml
@@ -10,8 +10,6 @@ workbench:
   domain: "local.ndslabs.org"
   subdomain_prefix: "www"
   volume_name: "global"
-  volume_path: "/ndslabs/data/volumes"
-  etcd_path: "/ndslabs/data/etcd"
   support_email: "ndslabs-support@nationaldataservice.org"
   require_account_approval: true
   specs:
@@ -22,6 +20,9 @@ workbench:
     apiserver: "ndslabs/apiserver:1.1.0"
     etcd: "ndslabs/etcd:2.2.5"
     smtp: "namshi/smtp:latest"
+  persistence:
+    accessMode: "ReadWriteMany"
+    size: "1Gi"
   
 # FIXME: This has not been tested
 oauth:

--- a/values.yaml
+++ b/values.yaml
@@ -23,6 +23,9 @@ workbench:
   persistence:
     accessMode: "ReadWriteOnce"
     size: "1Gi"
+  home_storage:
+    home_pvc_suffix: "-home"
+    pvc_storage_class: "nfs"
   
 # FIXME: This has not been tested
 oauth:

--- a/values.yaml
+++ b/values.yaml
@@ -26,7 +26,9 @@ workbench:
   home_storage:
     home_pvc_suffix: "-home"
     pvc_storage_class: "nfs"
-  
+  timeout: 30
+  inactivity_timeout: 480
+
 # FIXME: This has not been tested
 oauth:
   enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -20,8 +20,16 @@ workbench:
     apiserver: "ndslabs/apiserver:develop"
     etcd: "ndslabs/etcd:2.2.5"
     smtp: "namshi/smtp:latest"
-  persistence:
-    accessMode: "ReadWriteOnce"
+  etcd_storage:
+    persistent:
+      # Values can be "false" for no persistent storage, "aws" for awsElasticBlockStore,
+      # or "gce" for gcePersistentDisk
+      type: false
+      # If using awsElasticBlockStore enter the EBS volume id, if using gcePersistentDisk
+      # enter the persistent disk name
+      volume_id:
+    storage_class:
+    access_mode: "ReadWriteOnce"
     size: "1Gi"
   home_storage:
     home_pvc_suffix: "-home"


### PR DESCRIPTION
This PR proposes a number of changes to the Helm chart to support real PVCs and deployment on GKE. It includes:

* Persistent volume claim for etcd (note -- this won't work on OpenStack until we fix https://github.com/nds-org/ndslabs/issues/273)
* NGINX annotations for NGINX ILB on GKE
* Changes to how apiserver is accessed from UI/cauth within Pod
* Example NFS provisioner configuration intended for use on GKE
* Fixes smtp.gmail key names

To test on GKE, follow the instructions on https://ndslabs.readthedocs.io/en/latest/install/gke.html.