### PR TITLE
Update chart to use etcd3

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -338,7 +338,7 @@ spec:
         image: {{ required "Must specify an image for ndslabs-etcd" .Values.workbench.images.etcd }}
         command:
         - /usr/local/bin/etcd
-        - --bind-addr=0.0.0.0:4001
+        - --listen-client-urls=http://0.0.0.0:4001
         - --advertise-client-urls=http://127.0.0.1:4001
         - --data-dir=/var/etcd/data
         ports:

--- a/values.yaml
+++ b/values.yaml
@@ -18,7 +18,7 @@ workbench:
   images:
     webui: "ndslabs/angular-ui:develop"
     apiserver: "ndslabs/apiserver:develop"
-    etcd: "ndslabs/etcd:2.2.5"
+    etcd: "quay.io/coreos/etcd:v3.3"
     smtp: "namshi/smtp:latest"
   persistence:
     accessMode: "ReadWriteOnce"


### PR DESCRIPTION
This appears to be simpler than originally thought.  Updating to an etcd3.3 image and changing a command argument is working with the latest API changes.  The main point is to have an in-cluster etcd that can work with an NFS volume.

To test:
* Deploy the nfs-provisioner or nfs-client provisioner
* Install this chart 
* Run the postman tests

Seeing the usual:
```
client: etcd cluster is unavailable or misconfigured; error #0: client: endpoint http://localhost:4001 exceeded header timeout
```
Which suggests performance problems over NFS?

