### PR TITLE
Add pods/exec to RBAC to fix the /console endpoint

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ .Release.Name }}
 rules:
 - apiGroups: ["", "extensions", "apps", "batch", "policy", "rbac.authorization.k8s.io", "networking.k8s.io"]
-  resources: ["componentstatuses", "persistentvolumeclaims", "replicasets", "deployments", "events", "endpoints", "pods", "pods/log", "namespaces", "services", "replicationcontrollers", "secrets", "resourcequotas", "limitranges", "networkpolicies"]
+  resources: ["componentstatuses", "persistentvolumeclaims", "replicasets", "deployments", "events", "endpoints", "pods", "pods/log", "pods/exec", "namespaces", "services", "replicationcontrollers", "secrets", "resourcequotas", "limitranges", "networkpolicies"]
   verbs: ["get", "list", "watch", "update", "patch", "create", "delete"]
 - apiGroups: [""]
   resources: ["configmaps"]


### PR DESCRIPTION
## Problem
The `workbench` ClusterRole is missing the permission to create `pods/exec`. This resulted in the following error in the `apiserver` logs when attempting to use the "Console" function from the UI:
```go
E0909 16:46:30.501237      21 kube.go:869] pods "slxk9r-arpspoofhacker-h9w2z" is forbidden: User "system:serviceaccount:default:workbench" cannot create pods/exec in the namespace "lambert8"
E0909 16:46:30.501770      21 kube.go:852] read |0: file already closed
E0909 16:46:30.502455      21 kube.go:833] read tcp 10.244.0.9:30001->10.244.0.1:55980: use of closed network connection
```

## Approach
Add the missing RBAC permission to the `workbench` ClusterRole.

## How to Test
1. Deploy workbench via Helm Chart
2. Add and launch a stack, then wait for it to start
3. Once started, click the "Console" button to the right of the stack name
    * You should see a new tab open
    * A console to the running container should connect in the new tab and allow you to run commands remotely