### PR TITLE
Added missing Ingress rule to /swagger.yaml

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -140,6 +140,10 @@ spec:
         backend:
           serviceName: {{ .Release.Name }}
           servicePort: 80
+      - path: /swagger.yaml
+        backend:
+          serviceName: {{ .Release.Name }}
+          servicePort: 80
       - path: /ConfigModule.js
         backend:
           serviceName: {{ .Release.Name }}


### PR DESCRIPTION
## Problem
At some point during multiple refactorings, we missed that the Swagger UI view no longer works with our provided Ingress rules because `swagger.yaml` is not currently being served via Ingress.

Fixes https://github.com/nds-org/ndslabs/issues/295

## Approach
Added the missing rule to `/swagger.yaml`. This allows the Swagger spec to be read by the UI at runtime and fixes the Swagger UI / API Reference view of the Workbench.
