### PR TITLE
Add configuration options for shared volumes

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -24,6 +24,17 @@ data:
 {{ end }}
   workbench.home_storage.home_pvc_suffix: "{{ .Values.workbench.home_storage.home_pvc_suffix }}"
   workbench.home_storage.pvc_storage_class: "{{ .Values.workbench.home_storage.pvc_storage_class }}"
+
+{{ if .Values.workbench.shared_storage.enabled }}
+  workbench.shared_storage.read_only: "{{ .Values.workbench.shared_storage.read_only }}"
+  workbench.shared_storage.volume_name: {{ .Values.workbench.shared_storage.volume_name }}
+  workbench.shared_storage.volume_path: {{ .Values.workbench.shared_storage.volume_path }}
+{{ else }}
+  workbench.shared_storage.volume_path: /tmp/shared
+  workbench.shared_storage.read_only: "true"
+  workbench.shared_storage.volume_name: "shared"
+{{ end }}
+
   workbench.timeout: "{{ .Values.workbench.timeout }}"
   workbench.inactivity_timeout: "{{ .Values.workbench.inactivity_timeout }}"
 

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -27,10 +27,10 @@ data:
 
 {{ if .Values.workbench.shared_storage.enabled }}
   workbench.shared_storage.read_only: "{{ .Values.workbench.shared_storage.read_only }}"
-  workbench.shared_storage.volume_name: {{ .Values.workbench.shared_storage.volume_name }}
-  workbench.shared_storage.volume_path: {{ .Values.workbench.shared_storage.volume_path }}
+  workbench.shared_storage.volume_name: "{{ .Values.workbench.shared_storage.volume_name }}"
+  workbench.shared_storage.volume_path: "{{ .Values.workbench.shared_storage.volume_path }}"
 {{ else }}
-  workbench.shared_storage.volume_path: /tmp/shared
+  workbench.shared_storage.volume_path: "/tmp/shared"
   workbench.shared_storage.read_only: "true"
   workbench.shared_storage.volume_name: "shared"
 {{ end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -219,7 +219,7 @@ spec:
     requests:
       storage: {{ .Values.workbench.etcd_storage.size | quote }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -318,8 +318,23 @@ spec:
         - containerPort: 30002
           protocol: TCP
         env:
-          - name: SHARED_VOLUME_PATH
-            value: "/tmp/shared"
+{{ if .Values.workbench.shared_storage.enabled }}
+        - name: SHARED_VOLUME_PATH
+          valueFrom:
+            configMapKeyRef:
+              key: workbench.shared_storage.volume_path
+              name: workbench
+        - name: SHARED_VOLUME_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: workbench.shared_storage.volume_name
+              name: workbench
+        - name: SHARED_VOLUME_READ_ONLY
+          valueFrom:
+            configMapKeyRef:
+              key: workbench.shared_storage.read_only
+              name: workbench
+{{ end }}
           - name: SUPPORT_EMAIL
             valueFrom:
               configMapKeyRef:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -319,21 +319,21 @@ spec:
           protocol: TCP
         env:
 {{ if .Values.workbench.shared_storage.enabled }}
-        - name: SHARED_VOLUME_PATH
-          valueFrom:
-            configMapKeyRef:
-              key: workbench.shared_storage.volume_path
-              name: workbench
-        - name: SHARED_VOLUME_NAME
-          valueFrom:
-            configMapKeyRef:
-              key: workbench.shared_storage.volume_name
-              name: workbench
-        - name: SHARED_VOLUME_READ_ONLY
-          valueFrom:
-            configMapKeyRef:
-              key: workbench.shared_storage.read_only
-              name: workbench
+          - name: SHARED_VOLUME_PATH
+            valueFrom:
+              configMapKeyRef:
+                key: workbench.shared_storage.volume_path
+                name: workbench
+          - name: SHARED_VOLUME_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: workbench.shared_storage.volume_name
+                name: workbench
+          - name: SHARED_VOLUME_READ_ONLY
+            valueFrom:
+              configMapKeyRef:
+                key: workbench.shared_storage.read_only
+                name: workbench
 {{ end }}
           - name: SUPPORT_EMAIL
             valueFrom:

--- a/values.yaml
+++ b/values.yaml
@@ -37,6 +37,11 @@ workbench:
   home_storage:
     home_pvc_suffix: "-home"
     pvc_storage_class: "nfs"
+  shared_storage:
+    enabled: false
+    volume_name: "shared"
+    volume_path: "/tmp/shared"
+    read_only: true
   timeout: 30
   inactivity_timeout: 480
 


### PR DESCRIPTION
## Problem
Workbench support a few configurable options for shared storage, that will be mounted into every pod. This is deal for datasets that will be analyzed by end-users of the applications that Workbench offers.

There is no way to configure these options using the Helm chart, and changes must be manually applied to the cluster with `kubectl edit` to set it up and cause the state of the cluster to become desynchronized with that of the Helm chart. As such, future `helm update` commands would overwrite this manual configuration and conflict would ensue.

## Approach
* Add some configuration options for `workbench.shared_storage` to the Helm chart.
* Apply sensible defaults for when `shared_storage` is disabled

NOTE: Unless the `/shared` directory is an NFS export that is mounted to every node, this will currently only work on a single-node deployment. Adjustments will likely be needed in the ndslabs/apiserver code to use a PVC instead of hostPath for this shared data.

## How to Test
Prerequisites: 
* Kubernetes cluster running
* exactly one default Storage Class (e.g. `hostpath`, `nfs`, etc)
* Helm client installed
* Tiller pod ready
* Backup or export any manual changes made to your cluster

Steps:
1. Checkout this branch locally: `git fetch --all && git checkout shared-volume-configuration`
2. Edit `values.yaml` and scroll to the `workbench.shared_storage` section
    * You should see four new configuration options here
3. Adjust the values of the following options:
    * `workbench.shared_storage.enabled` to `true` (true / false)
    * `workbench.shared_storage.volume_name` to `shared` (arbitrary string identifier, may be lowercase letters only)
    * `workbench.shared_storage.volume_path` to `/shared` (absolute path to shared directory on the host)
    * `workbench.shared_storage.read_only` to `true` (true / false)
4. From the repository root, upgrade the Helm chart: 
    * `helm upgrade --install workbench .`
5. Navigate to the Workbench platform, sign up a user, and log in
    * You should be brought to the Catalog view (if you haven't already added any applications)
6. Add any application from the Catalog and click View
    * You should be brought to the Dashboard view, with your new application expanded
7. Click Launch to start your application instance and wait for your application to start
8. Once started, open a Console to your application from the Dashboard
9. In the Console, perform an `ls -al /shared` to verify the contents of the shared directory
10. Attempt to write to the shared directory to verify that it is read-only
    * `echo "hello world" > /shared/test-write-access`
    * You should receive an error about a `Read-only filesystem` when attempting to write