### PR TITLE
Remove duplicate /dashboard ingress path

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -76,13 +76,6 @@ spec:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /dashboard
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ .Release.Name }}
-            port: 
-              number: 80
       - path: /cauth
         pathType: Prefix
         backend:


### PR DESCRIPTION
# Problem
This fixes /cauth and SSO with oauth2-proxy.

Duplicate ingress path for `/dashboard` prevents SSO from working properly. Accessing `/dashboard` paths would match on `workbench-open` ingress before matching `workbench-auth`. This prevented accesses to `/dashboard` resources from being properly authenticated via `/cauth` SSO and the `oauth2-proxy`.

# Approach
Remove the duplicate path.

# How to Test?
TBD