### PR TITLE
Fix / Enable OAuth configuration

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -11,7 +11,6 @@ data:
   workbench.ingress.tls.enable: "true"
   workbench.ingress.tls.cluster_issuer: "{{ default "" .Values.certmgr.cluster_issuer }}"
   workbench.ingress.tls.issuer: "{{ default "" .Values.certmgr.issuer }}"
-  workbench.ingress.tls.namespace: "{{ default "" .Values.certmgr.namespace }}"
 
   # Customize this instance of Workbench
   workbench.subdomain_prefix: "{{ .Values.workbench.subdomain_prefix }}"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -55,11 +55,6 @@ spec:
     - port: 30001
       name: api
       protocol: TCP
-{{ if .Values.oauth.enabled | default false }}
-    - port: 30002
-      name: admin
-      protocol: TCP
-{{ end }}
     - name: smtp
       port: 25
       protocol: TCP

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -55,6 +55,11 @@ spec:
     - port: 30001
       name: api
       protocol: TCP
+{{ if .Values.oauth.enabled | default false }}
+    - port: 30002
+      name: admin
+      protocol: TCP
+{{ end }}
     - name: smtp
       port: 25
       protocol: TCP

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -76,13 +76,6 @@ spec:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /dashboard
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ .Release.Name }}
-            port: 
-              number: 80
       - path: /cauth
         pathType: Prefix
         backend:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -23,7 +23,11 @@ spec:
     - '*.{{ .Values.workbench.domain }}'
     secretName: {{ .Values.tls.secretName }}
   rules:
-{{ if .Values.workbench.subdomain_prefix }}  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}{{ else }}  - host: {{ .Values.workbench.domain }}{{ end }}
+{{ if .Values.workbench.subdomain_prefix }}
+  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}
+{{ else }}
+  - host: {{ .Values.workbench.domain }}
+{{ end }}
     http:
       paths:
       - path: /logs
@@ -48,11 +52,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-#{{ if .Values.certmgr.cluster_issuer }}
-    cert-manager.io/cluster-issuer: "{{ .Values.certmgr.cluster_issuer }}"
-{{ else if .Values.certmgr.issuer }}
-    cert-manager.io/issuer: "{{ .Values.certmgr.issuer }}"
-{{ end }}
     nginx.ingress.kubernetes.io/app-root: "/landing/"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
@@ -63,7 +62,11 @@ spec:
     - '*.{{ .Values.workbench.domain }}'
     secretName: {{ .Values.tls.secretName }}
   rules:
-{{ if .Values.workbench.subdomain_prefix }}  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}{{ else }}  - host: {{ .Values.workbench.domain }}{{ end }}
+{{ if .Values.workbench.subdomain_prefix }}
+  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}
+{{ else }}
+  - host: {{ .Values.workbench.domain }}
+{{ end }}
     http:
       paths:
       - path: /api/
@@ -122,3 +125,44 @@ spec:
             name: {{ .Release.Name }}
             port: 
               number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+{{ if .Values.certmgr.cluster_issuer }}
+    cert-manager.io/cluster-issuer: "{{ .Values.certmgr.cluster_issuer }}"
+{{ else if .Values.certmgr.issuer }}
+    cert-manager.io/issuer: "{{ .Values.certmgr.issuer }}"
+{{ end }}
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+{{ if .Values.workbench.subdomain_prefix }}
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/landing/"
+{{ else }}
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.domain }}/landing/"
+{{ end }}
+  name: {{ .Release.Name }}-root
+  namespace: {{ .Release.Namespace }}
+spec:
+  rules:
+{{ if .Values.workbench.subdomain_prefix }}
+  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}
+{{ else }}
+  - host: {{ .Values.workbench.domain }}
+{{ end }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Release.Name }}
+            port: 
+              number: 80
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - {{ .Values.workbench.domain }}
+    - '*.{{ .Values.workbench.domain }}'
+    secretName: {{ .Values.tls.secretName }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-{{ if .Values.oauth.enabled | default true }}
+{{ if .Values.oauth.enabled | default false }}
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.oauth.auth_url | default "https://$host/cauth/auth" }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.oauth.signin_url | default "https://$host/login/" }}"
     nginx.ingress.kubernetes.io/auth-request-headers: "{{ .Values.oauth.auth_request_headers | default "x-auth-request-user, x-auth-request-email" }}"
@@ -21,7 +21,7 @@ spec:
   - hosts:
     - {{ .Values.workbench.domain }}
     - '*.{{ .Values.workbench.domain }}'
-    secretName: {{ .Values.tls.secretName }}-auth
+    secretName: {{ .Values.tls.secretName }}
   rules:
 {{ if .Values.workbench.subdomain_prefix }}  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}{{ else }}  - host: {{ .Values.workbench.domain }}{{ end }}
     http:
@@ -48,6 +48,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
+#{{ if .Values.certmgr.cluster_issuer }}
+    cert-manager.io/cluster-issuer: "{{ .Values.certmgr.cluster_issuer }}"
+{{ else if .Values.certmgr.issuer }}
+    cert-manager.io/issuer: "{{ .Values.certmgr.issuer }}"
+{{ end }}
+    nginx.ingress.kubernetes.io/app-root: "/landing/"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
@@ -55,106 +61,64 @@ spec:
   - hosts:
     - {{ .Values.workbench.domain }}
     - '*.{{ .Values.workbench.domain }}'
+    secretName: ndslabs-tls
   rules:
 {{ if .Values.workbench.subdomain_prefix }}  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}{{ else }}  - host: {{ .Values.workbench.domain }}{{ end }}
     http:
       paths:
-      - path: /api
+      - path: /api/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 30001
-      - path: /login
+      - path: /login/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /landing
+      - path: /landing/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /cauth
+      - path: /cauth/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /shared
+      - path: /shared/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /bower_components
+      - path: /node_modules/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /node_modules
+      - path: /asset/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /asset
+      - path: /
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /swagger.yaml
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ .Release.Name }}
-            port: 
-              number: 80
-      - path: /ConfigModule.js
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ .Release.Name }}
-            port: 
-              number: 80
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  annotations:
-    kubernetes.io/ingress.class: "nginx"
-{{ if .Values.certmgr.cluster_issuer }}    cert-manager.io/cluster-issuer: "{{ .Values.certmgr.cluster_issuer }}"{{ else if .Values.certmgr.issuer }}    cert-manager.io/issuer: "{{ .Values.certmgr.issuer }}"{{ end }}
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-{{ if .Values.workbench.subdomain_prefix }}    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/landing/"{{ else }}    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.domain }}/landing/"{{ end }}
-  name: {{ .Release.Name }}-root
-  namespace: {{ .Release.Namespace }}
-spec:
-  rules:
-{{ if .Values.workbench.subdomain_prefix }}  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}{{ else }}  - host: {{ .Values.workbench.domain }}{{ end }}
-    http:
-      paths:
-      - backend:
-          service:
-            name: {{ .Release.Name }}
-            port: 
-              number: 80
-        path: /
-        pathType: Prefix
-  tls:
-  - hosts:
-    - {{ .Values.workbench.domain }}
-    - '*.{{ .Values.workbench.domain }}'
-    secretName: {{ .Values.tls.secretName }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -6,10 +6,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-{{ if .Values.workbench.subdomain_prefix }}    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/cauth/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/login/"
-{{ else }}    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.workbench.domain }}/cauth/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.workbench.domain }}/login/"{{ end }}
+{{ if .Values.oauth.enabled | default true }}
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.oauth.auth_url | default "https://$host/cauth/auth" }}"
+    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.oauth.signin_url | default "https://$host/login/" }}"
+    nginx.ingress.kubernetes.io/auth-request-headers: "{{ .Values.oauth.auth_request_headers | default "x-auth-request-user, x-auth-request-email" }}"
+{{ else }}
+    nginx.ingress.kubernetes.io/auth-url: "https://$host/cauth/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://$host/login/"
+{{ end }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 {{ if .Values.oauth.enabled | default false }}
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.oauth.auth_url | default "https://$host/cauth/auth" }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.oauth.signin_url | default "https://$host/login/" }}"
-    nginx.ingress.kubernetes.io/auth-request-headers: "{{ .Values.oauth.auth_request_headers | default "x-auth-request-user, x-auth-request-email" }}"
+    nginx.ingress.kubernetes.io/auth-response-headers: "{{ .Values.oauth.auth_response_headers | default "x-auth-request-user, x-auth-request-email" }}"
 {{ else }}
     nginx.ingress.kubernetes.io/auth-url: "https://$host/cauth/auth"
     nginx.ingress.kubernetes.io/auth-signin: "https://$host/login/"
@@ -61,7 +61,7 @@ spec:
   - hosts:
     - {{ .Values.workbench.domain }}
     - '*.{{ .Values.workbench.domain }}'
-    secretName: ndslabs-tls
+    secretName: {{ .Values.tls.secretName }}
   rules:
 {{ if .Values.workbench.subdomain_prefix }}  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}{{ else }}  - host: {{ .Values.workbench.domain }}{{ end }}
     http:

--- a/values.yaml
+++ b/values.yaml
@@ -45,16 +45,15 @@ workbench:
   timeout: 30
   inactivity_timeout: 480
 
-# FIXME: This has not been tested
 oauth:
   enabled: false
-  signin_url: ""
-  auth_url: ""
+  signin_url: "https://$host/login/"
+  auth_url: "https://$host/cauth/auth"
+  auth_request_headers: "x-auth-request-user, x-auth-request-email"
 
 certmgr:
   cluster_issuer: "acmedns-issuer"
   issuer: ""
-  namespace: ""
 
 rbac:
   enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -49,7 +49,7 @@ oauth:
   enabled: false
   signin_url: "https://$host/login/"
   auth_url: "https://$host/cauth/auth"
-  auth_request_headers: "x-auth-request-user, x-auth-request-email"
+  auth_response_headers: "x-auth-request-user, x-auth-request-email" # , x-auth-request-access-token, x-auth-request-redirect, x-auth-request-preferred-username"
 
 certmgr:
   cluster_issuer: "acmedns-issuer"


### PR DESCRIPTION
## Problem
Login via OAuth2 is supported via ingress annotations in the NGINX ingress controller.
There is no way to currently configure this automatically via the Helm chart.

NOTE: There are some stubbed-out configs in `values.yaml` for this that do not currently wire up to anything 

## Approach
Allow user to configure `oauth` proxy paths in the `values.yaml`

## How to Test
NOTE: This uses the test Docker images built from https://github.com/nds-org/ndslabs/pull/336



#### Prerequisites:
* Kubernetes Cluster deployed
* NGINX Ingress controller running
* at least one `StorageClass` or have a cluster-level default set
* TLS cert generated, or `cert-manager` properly configured w/ ACMEDNS support for wildcard cert generation

#### Initial Setup
NOTE: By default, this Helm chart deploys version ~5.1 of the oauth2-proxy. Newest release is 7.0.0

1. Checkout this branch locally
2. Create a secret from your TLS certificate (if not using `cert-manager`): `kubectl create secret tls ndslabs-tls --key ${KEY_FILE} --cert ${CERT_FILE}`
2. Edit `values.yaml` to set the following:
    * `workbench.image.webui: ndslabs/angular-ui:external-auth` - image has additional code to send `_oauth2_proxy` cookie to new API endpoint
    * `workbench.image.apiserver: ndslabs/apiserver:external-auth` - image has additional code to send `_oauth2_proxy` cookie back to the `oauth2-proxy` to fetch from its `/userinfo` endpoint
    * `workbench.support.email` / `smtp.gmail_user` / `smtp_gmail_pass` to your GMail app credentials
    * `workbench.domain` / `workbench.subdomain_prefix` (Defaults to: `local.ndslabs.org` / `www`)
    * `workbench.etcd_storage.storage_class` / `workbench.home_storage.pvc_storage_class` (Defaults to: "")
3. Deploy Workbench: `helm upgrade --install workbench . -f values.yaml`
4. Attempt to navigate directly to https://www.local.ndslabs.org/dashboard
    * You should be taken instead to https://www.local.ndslabs.org/login
    * You should see an `?rd=` parameter in the URL query string pointing to the dashboard
5. Login to the Workbench
    * You should be redirected to where your `?rd=` parameter was pointing

#### Setup: Configuring `oauth2-proxy` to use GitHub
Final chain: Workbench -> oauth2-proxy -> Github -> Workbench

1. Create a new OAuth application in GitHub - be sure to save the `clientId` and `clientSecret`: https://github.com/settings/developers
2. Generate a new `cookieSecret` by executing the following: `python -c 'import os,base64; print base64.b64encode(os.urandom(16))'`
3. Create a Kubernetes Secret from your new GitHub OAuth credentials:
```bash
kubectl -n default create secret generic oauth2-proxy-creds \
--from-literal=cookie-secret=${COOKIE_SECRET} \
--from-literal=client-id=${GITHUB_CLIENT_ID} \
--from-literal=client-secret=${GITHUB_CLIENT_SECRET}
```
4. Create a file called `oauth-proxy-config.github.yaml`:
```yaml

config:
  existingSecret: oauth2-proxy-creds

extraArgs:
  whitelist-domain: .local.ndslabs.org
  cookie-domain: .local.ndslabs.org
  provider: github

authenticatedEmailsFile:
  enabled: true
  restricted_access: |-
    your@email.com

ingress:
  enabled: true
  path: /oauth2
  hosts:
    - www.local.ndslabs.org
  annotations:
  tls:
    - secretName: ndslabs-tls
      hosts:
        - www.local.ndslabs.org
```
5. Deploy the oauth2-proxy Helm chart: `helm upgrade oauth2-proxy --install stable/oauth2-proxy --values oauth2-proxy-config.github.yaml`
6. Edit the Workbench Helm chart's`values.yaml`, and set the following:
```yaml
workbench:
  image:
    apiserver: ndslabs/apiserver:external-auth
    webui: ndslabs/angular-ui:external-auth
oauth:
  enabled: true
  auth_url: "https://$host/oauth2/auth"
  signin_url: "https://$host/oauth2/start?rd=$escaped_request_uri"
  auth_response_headers: "x-auth-request-user, x-auth-request-email"
```
8. Deploy the new Helm chart values into Workbench: `helm upgrade --install workbench . -f values.yaml`

#### Setup: Configuring `oauth2-proxy` to use Globus
Final chain: Workbench -> oauth2-proxy -> Globus -> NCSA -> 2FA -> Workbench

NOTE: These steps require using a custom-built version the `oauth2-proxy` Docker image that adds the Globus provider. This will be submitted back to the project as a PR.
 
1. Redeploy the `oauth2-proxy` Helm chart with the following `oauth2-values.globus.yaml`:
```yaml
image:
  repository: ndslabs/oauth2-proxy
  tag: globus-provider
  pullPolicy: Always

extraArgs:
  whitelist-domain: .local.ndslabs.org
  cookie-domain: .local.ndslabs.org
  provider: globus
  client-id: ""
  client-secret: ""
  cookie-secret: ""   # Generate with python -c 'import os,base64; print base64.b64encode(os.urandom(16))'

authenticatedEmailsFile:
  enabled: true
  restricted_access: |-
    your@email.com

ingress:
  enabled: true
  path: /oauth2
  hosts:
    - www.local.ndslabs.org
  annotations:
  tls:
    # Reuse ndslabs wildcard certificate
    - secretName: ndslabs-tls
      hosts:
        - www.local.ndslabs.org
```

#### Setup: Configuring `oauth2-proxy` to use Keycloak + CILogon
Final chain: Workbench -> oauth2-proxy -> Keycloak -> CILogon -> NCSA -> 2FA -> Workbench

NOTE 1: These steps require using a custom-built version the `oauth2-proxy` Docker image that enriches the key. This will be submitted back to the project as a PR.

NOTE 2: The names of the Realm / Client / Identity Provider created below are important, and are used later on to build up the callback URLs we will use in the `oauth2-proxy`

##### Deploying Keycloak
1. Deploy Keycloak to your Kubernetes cluster as described in the [docs](https://www.keycloak.org/getting-started/getting-started-kube): `kubectl create -f https://raw.githubusercontent.com/keycloak/keycloak-quickstarts/latest/kubernetes-examples/keycloak.yaml`
    * I changed the ingress rules here to `keycloak.local.ndslabs.org`, allowing me to reuse the wildcard cert for `*.local.ndslabs.org`
    * NOTE: Eventually, we will want to deploy Keycloak via Helm chart
2. Log into your Keycloak instance via the default credentials: `admin` / `admin`

##### Configuring Keycloak + CILogon
Source: https://osc.github.io/ood-documentation/release-1.7/authentication/tutorial-oidc-keycloak-rhel7/configure-cilogon.html#register-your-keycloak-instance-with-cilogon

1. Create a Realm named `workbench` in Keycloak, switch to the Realm using the selector at the top-left
2. Register a new OAuth application with CILogon: https://cilogon.org/oauth2/register
    * NOTE: You should save the ClientId and ClientSecret
3. On the left side, click on `Identity Providers` - create an [OIDC Identity Provider](https://www.keycloak.org/docs/latest/server_admin/#_identity_broker_oidc) in Keycloak named `CILogon` using the ClientId and ClientSecret that CILogon returned to you
4. Wait for the CILogon administrators to approve your application
    * NOTE: this shouldn't take longer than a few hours on a normal business day
5. On the left side, click on `Clients` - create a [Client](https://www.keycloak.org/docs/latest/server_admin/#oidc-clients) in Keycloak name `cilogon` for the CILogon Identity Provider
6. On the left side, click on `Authentication` - create a new [Authentication Flow](https://www.keycloak.org/docs/latest/server_admin/#_authentication-flows) called "Simple First Login" and add a single "REQUIRED" execution step of "Create New User (if Unique)"
    * This tells Keycloak how to handle our users on first login - in our case, we simply want to ensure the user exists in Keycloak
    * NOTE: Eventually, we will want to expand this with a more robust new sign-up process (e.g. handling linking multiple accounts and more advanced use cases)

NOTE: There may be more that we can do here with Mappings and Scopes to provide more info, but I don't understand enough about Keycloak/OAuth2 to know for sure if that gains us anything valuable for Workbench.

##### Configuring Keycloak + `oauth2-proxy`
Source: https://docs.syseleven.de/metakube/de/tutorials/setup-ingress-auth-to-use-keycloak-oauth

1. If you're running on `localhost` or `.local.ndslabs.org`, then you'll need to add the following magic snippet in your `templates/deployment.yaml`:
```yaml
      hostAliases:
      # TODO: How can we parameterize this IP?
      # To get, run: "kubectl get svc -n kube-system" and get nginx service IP
      - ip: "10.110.50.133"    
        hostnames:
        - "{{ .Values.workbench.subdomain_prefix}}.{{ .Values.workbench.domain }}"
```
    * Background: Since `www.local.ndslabs.org` resolves to `127.0.0.1`, within a container it doesn't resolve to the ingress controller and so traffic never reaches our Pod. To fix this and talk directly to the oauth2-proxy, we can use `hostAlises` to add static entries to the `/etc/hosts` file so that we can hit the ingress controller. Obviously this is for development environments only, and configurations `hostAliases` should not be used in production systems.
2. Redeploy the `oauth2-proxy` Helm chart with the following `oauth2-values.keycloak.yaml`:
```yaml
image:
  repository: ndslabs/oauth2-proxy
  tag: enrich-keycloak-session
  pullPolicy: Always

extraArgs:
  whitelist-domain: .local.ndslabs.org
  cookie-domain: .local.ndslabs.org
  scope: "openid email profile"
  provider: keycloak
  provider-display-name: Workbench Login
  login-url: "https://keycloak.local.ndslabs.org/auth/realms/workbench/protocol/openid-connect/auth" # Change REALM_NAME to your realm
  redeem-url: "https://keycloak.local.ndslabs.org/auth/realms/workbench/protocol/openid-connect/token" # Change REALM_NAME to your realm
  profile-url: "https://keycloak.local.ndslabs.org/auth/realms/workbench/protocol/openid-connect/userinfo" # Change REALM_NAME to your realm
  validate-url: "https://keycloak.local.ndslabs.org/auth/realms/workbench/protocol/openid-connect/userinfo" # Change REALM_NAME to your realm
  set-xauthrequest: true
  set-authorization-header: true
  client-id: "cilogon"    # Must match "Client" ID in Keycloak
  client-secret: "f8ec195f-b104-4c36-8ede-f1a268a5626a"     # Must match "Client" Secret (See Credentials tabs in Keycloak)
  cookie-secret: ""      # Generate with python -c 'import os,base64; print base64.b64encode(os.urandom(16))'
  #keycloak-group: "approved"    # Change XXX by your group that shall have access to it - this was not tested

authenticatedEmailsFile:
  enabled: true
  restricted_access: |-
    your@email.com

ingress:
  enabled: true
  path: /oauth2
  hosts:
    - www.local.ndslabs.org
  annotations:
  tls:
    # Reuse ndslabs wildcard certificate
    - secretName: ndslabs-tls
      hosts:
        - www.local.ndslabs.org
```

#### Test Steps
With any of the above providers configured, test steps should be identical:

1. Attempt to navigate directly to https://www.local.ndslabs.org/dashboard
    * You should be taken instead to https://www.local.ndslabs.org/oauth2/signin
    * You should see an `?rd=` parameter in the URL query string pointing to the dashboard
2. Login to the Workbench
    * You should be redirected through one or more providers to sign-in / authorize
3. Sign in and authorize this application
    * You should be redirected back to the dashboard page with a valid session
    * You should see your user info appear at the top-right
    * You should see any applications that you have previously added on your Workbench account load into your Dashboard