### PR TITLE
[WIP] OAuth configuration for hostAliases when running on local.ndslabs.org

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -11,7 +11,6 @@ data:
   workbench.ingress.tls.enable: "true"
   workbench.ingress.tls.cluster_issuer: "{{ default "" .Values.certmgr.cluster_issuer }}"
   workbench.ingress.tls.issuer: "{{ default "" .Values.certmgr.issuer }}"
-  workbench.ingress.tls.namespace: "{{ default "" .Values.certmgr.namespace }}"
 
   # Customize this instance of Workbench
   workbench.subdomain_prefix: "{{ .Values.workbench.subdomain_prefix }}"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -130,6 +130,11 @@ spec:
 {{ if .Values.rbac.enabled }}
       serviceAccountName: {{ .Release.Name }}
 {{ end }}
+      # How can we parameterize this IP?
+      hostAliases:
+      - ip: "10.110.50.133"
+        hostnames:
+        - "{{ .Values.workbench.subdomain_prefix}}.{{ .Values.workbench.domain }}"
       volumes:
        - persistentVolumeClaim:
             claimName: {{ .Release.Name }}-etcd

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -55,6 +55,11 @@ spec:
     - port: 30001
       name: api
       protocol: TCP
+{{ if .Values.oauth.enabled | default false }}
+    - port: 30002
+      name: admin
+      protocol: TCP
+{{ end }}
     - name: smtp
       port: 25
       protocol: TCP

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -76,13 +76,6 @@ spec:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /dashboard
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ .Release.Name }}
-            port: 
-              number: 80
       - path: /cauth
         pathType: Prefix
         backend:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-{{ if .Values.oauth.enabled | default true }}
+{{ if .Values.oauth.enabled | default false }}
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.oauth.auth_url | default "https://$host/cauth/auth" }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.oauth.signin_url | default "https://$host/login/" }}"
     nginx.ingress.kubernetes.io/auth-request-headers: "{{ .Values.oauth.auth_request_headers | default "x-auth-request-user, x-auth-request-email" }}"
@@ -21,7 +21,7 @@ spec:
   - hosts:
     - {{ .Values.workbench.domain }}
     - '*.{{ .Values.workbench.domain }}'
-    secretName: {{ .Values.tls.secretName }}-auth
+    secretName: {{ .Values.tls.secretName }}
   rules:
 {{ if .Values.workbench.subdomain_prefix }}  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}{{ else }}  - host: {{ .Values.workbench.domain }}{{ end }}
     http:
@@ -48,6 +48,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
+#{{ if .Values.certmgr.cluster_issuer }}
+    cert-manager.io/cluster-issuer: "{{ .Values.certmgr.cluster_issuer }}"
+{{ else if .Values.certmgr.issuer }}
+    cert-manager.io/issuer: "{{ .Values.certmgr.issuer }}"
+{{ end }}
+    nginx.ingress.kubernetes.io/app-root: "/landing/"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
@@ -55,106 +61,64 @@ spec:
   - hosts:
     - {{ .Values.workbench.domain }}
     - '*.{{ .Values.workbench.domain }}'
+    secretName: ndslabs-tls
   rules:
 {{ if .Values.workbench.subdomain_prefix }}  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}{{ else }}  - host: {{ .Values.workbench.domain }}{{ end }}
     http:
       paths:
-      - path: /api
+      - path: /api/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 30001
-      - path: /login
+      - path: /login/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /landing
+      - path: /landing/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /cauth
+      - path: /cauth/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /shared
+      - path: /shared/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /bower_components
+      - path: /node_modules/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /node_modules
+      - path: /asset/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /asset
+      - path: /
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /swagger.yaml
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ .Release.Name }}
-            port: 
-              number: 80
-      - path: /ConfigModule.js
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ .Release.Name }}
-            port: 
-              number: 80
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  annotations:
-    kubernetes.io/ingress.class: "nginx"
-{{ if .Values.certmgr.cluster_issuer }}    cert-manager.io/cluster-issuer: "{{ .Values.certmgr.cluster_issuer }}"{{ else if .Values.certmgr.issuer }}    cert-manager.io/issuer: "{{ .Values.certmgr.issuer }}"{{ end }}
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-{{ if .Values.workbench.subdomain_prefix }}    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/landing/"{{ else }}    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.domain }}/landing/"{{ end }}
-  name: {{ .Release.Name }}-root
-  namespace: {{ .Release.Namespace }}
-spec:
-  rules:
-{{ if .Values.workbench.subdomain_prefix }}  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}{{ else }}  - host: {{ .Values.workbench.domain }}{{ end }}
-    http:
-      paths:
-      - backend:
-          service:
-            name: {{ .Release.Name }}
-            port: 
-              number: 80
-        path: /
-        pathType: Prefix
-  tls:
-  - hosts:
-    - {{ .Values.workbench.domain }}
-    - '*.{{ .Values.workbench.domain }}'
-    secretName: {{ .Values.tls.secretName }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -6,10 +6,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-{{ if .Values.workbench.subdomain_prefix }}    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/cauth/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/login/"
-{{ else }}    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.workbench.domain }}/cauth/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.workbench.domain }}/login/"{{ end }}
+{{ if .Values.oauth.enabled | default true }}
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.oauth.auth_url | default "https://$host/cauth/auth" }}"
+    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.oauth.signin_url | default "https://$host/login/" }}"
+    nginx.ingress.kubernetes.io/auth-request-headers: "{{ .Values.oauth.auth_request_headers | default "x-auth-request-user, x-auth-request-email" }}"
+{{ else }}
+    nginx.ingress.kubernetes.io/auth-url: "https://$host/cauth/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://$host/login/"
+{{ end }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 {{ if .Values.oauth.enabled | default false }}
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.oauth.auth_url | default "https://$host/cauth/auth" }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.oauth.signin_url | default "https://$host/login/" }}"
-    nginx.ingress.kubernetes.io/auth-request-headers: "{{ .Values.oauth.auth_request_headers | default "x-auth-request-user, x-auth-request-email" }}"
+    nginx.ingress.kubernetes.io/auth-response-headers: "{{ .Values.oauth.auth_response_headers | default "x-auth-request-user, x-auth-request-email" }}"
 {{ else }}
     nginx.ingress.kubernetes.io/auth-url: "https://$host/cauth/auth"
     nginx.ingress.kubernetes.io/auth-signin: "https://$host/login/"
@@ -61,7 +61,7 @@ spec:
   - hosts:
     - {{ .Values.workbench.domain }}
     - '*.{{ .Values.workbench.domain }}'
-    secretName: ndslabs-tls
+    secretName: {{ .Values.tls.secretName }}
   rules:
 {{ if .Values.workbench.subdomain_prefix }}  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}{{ else }}  - host: {{ .Values.workbench.domain }}{{ end }}
     http:

--- a/values.yaml
+++ b/values.yaml
@@ -45,16 +45,15 @@ workbench:
   timeout: 30
   inactivity_timeout: 480
 
-# FIXME: This has not been tested
 oauth:
   enabled: false
-  signin_url: ""
-  auth_url: ""
+  signin_url: "https://$host/login/"
+  auth_url: "https://$host/cauth/auth"
+  auth_request_headers: "x-auth-request-user, x-auth-request-email"
 
 certmgr:
   cluster_issuer: "acmedns-issuer"
   issuer: ""
-  namespace: ""
 
 rbac:
   enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -49,7 +49,7 @@ oauth:
   enabled: false
   signin_url: "https://$host/login/"
   auth_url: "https://$host/cauth/auth"
-  auth_request_headers: "x-auth-request-user, x-auth-request-email"
+  auth_response_headers: "x-auth-request-user, x-auth-request-email" # , x-auth-request-access-token, x-auth-request-redirect, x-auth-request-preferred-username"
 
 certmgr:
   cluster_issuer: "acmedns-issuer"


### PR DESCRIPTION
## Problem
EDGE CASE: When running on `www.local.ndslabs.org`, everything under `*.local.ndslabs.org` will resolve to `localhost`. This presents a problem on the off-chance that they attempt to access the domain directly from within a Pod.

Note that `minikube` will likely not encounter the same problem, because it runs on its own IP and does not rely on `localhost` resolving properly.

For example, when the API receives a request to register/authenticate a user via OAuth, it needs to reach out to the `oauth2-proxy` Pod to verify the authenticity of the token. In doing so, it sends a request to `www.local.ndslabs.org/oauth/userinfo`. This ultimately resolves to `localhost/oauth/userinfo` which does not exist within the container, causing the request to fail.

## Approach
Include an optional snippet in the `deployment.yaml` to resolve to the Ingress controller instead, so that our request can be properly

## How to Test
1. Run a Kubernetes cluster using Docker for MacOSX or Docker for Windows
    * NOTE: `minikube` should not encounter the same problem
2. Run and configure OAuth2 Proxy + Keycloak + CILogon (See [Setup: Configuring oauth2-proxy to use Keycloak + CILogon](https://github.com/nds-org/workbench-helm-chart/pull/24))
3. Deploy the Helm chart from the `oauth-configuration` branch to use OAuth and to run on `local.ndslabs.org`
     * NOTE: this domain always resolves to `localhost`
4. Attempt to sign into the Workbench via OAuth
    * NOTE: This will *fail* when using `local.ndslabs.org`
5. Run `kubectl logs -f deploy/workbench -c apiserver`
    * You should see an error in the `apiserver` logs from attempting to validate the OAuth token
6. Checkout this branch and redeploy the Helm chart, run `kubectl get deploy workbench -o yaml`
    * You should see that a `hostAliases` configuration within the Workbench Deployment
7. Attempt to sign in once more to the Workbench via OAuth
    * You should now be allowed into the platform with an OAuth user account
    * You should no longer see an error in the `apiserver` logs for this action 

## TODOs
* How can we fetch this IP programmatically? Does Helm offer a way to consume Service discovery envvars in our templates? Alternatively, we can standardize the namespace of our Ingress deployment and rely on Cluster DNS to resolve things.
* Make the `hostAliases` segment conditional, only present if `.Values.workbench.domain == "local.ndslabs.org"`