### PR TITLE
Feature Branch: Workbench CDDR

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -4,6 +4,14 @@ metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 data:
+  frontend.json: |
+    {{ .Values.frontend | toJson }}
+  backend.json: |
+    {{ .Values.backend | toJson }}
+
+
+  ### DEPRECATED: 
+
   # Enable TLS (HTTPS)?
   workbench.tls.enable: "true"
 
@@ -28,10 +36,13 @@ data:
   workbench.advanced_features.show_file_manager: "{{ .Values.workbench.advanced_features.show_file_manager }}"
 
   workbench.name: "{{ .Values.workbench.name }}"
-  workbench.landing_html: {{ .Values.workbench.landing_html | quote }}
+  workbench.landing_html: >- 
+    {{ .Values.workbench.landing_html }}
   workbench.brand_logo_path: {{ .Values.workbench.brand_logo_path | quote }}
   workbench.favicon_path: {{ .Values.workbench.favicon_path | quote }}
   workbench.learn_more_url: {{ .Values.workbench.learn_more_url | quote }}
+  workbench.help_links: {{ .Values.workbench.help_links | quote }}
+
   workbench.support_email: "{{ .Values.workbench.support_email }}"
   workbench.analytics_tracking_id: "{{ .Values.workbench.analytics_tracking_id }}"
   workbench.node_selector_name: "{{ .Values.workbench.node_selector_name }}"

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -15,7 +15,23 @@ data:
   # Customize this instance of Workbench
   workbench.subdomain_prefix: "{{ .Values.workbench.subdomain_prefix }}"
   workbench.domain: "{{ .Values.workbench.domain }}"
+  workbench.cookie_domain: "{{ .Values.workbench.domain }}"
+
+  workbench.advanced_features.show_config: "{{ .Values.workbench.advanced_features.show_config }}"
+  workbench.advanced_features.show_logs: "{{ .Values.workbench.advanced_features.show_logs }}"
+  workbench.advanced_features.show_console: "{{ .Values.workbench.advanced_features.show_console }}"
+  workbench.advanced_features.show_service_help_icon: "{{ .Values.workbench.advanced_features.show_service_help_icon }}"
+  workbench.advanced_features.show_edit_service: "{{ .Values.workbench.advanced_features.show_edit_service }}"
+  workbench.advanced_features.show_remove_service: "{{ .Values.workbench.advanced_features.show_remove_service }}"
+  workbench.advanced_features.show_create_spec: "{{ .Values.workbench.advanced_features.show_create_spec }}"
+  workbench.advanced_features.show_import_spec: "{{ .Values.workbench.advanced_features.show_import_spec }}"
+  workbench.advanced_features.show_file_manager: "{{ .Values.workbench.advanced_features.show_file_manager }}"
+
   workbench.name: "{{ .Values.workbench.name }}"
+  workbench.landing_html: {{ .Values.workbench.landing_html | quote }}
+  workbench.brand_logo_path: {{ .Values.workbench.brand_logo_path | quote }}
+  workbench.favicon_path: {{ .Values.workbench.favicon_path | quote }}
+  workbench.learn_more_url: {{ .Values.workbench.learn_more_url | quote }}
   workbench.support_email: "{{ .Values.workbench.support_email }}"
   workbench.analytics_tracking_id: "{{ .Values.workbench.analytics_tracking_id }}"
   workbench.node_selector_name: "{{ .Values.workbench.node_selector_name }}"

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -11,7 +11,6 @@ data:
   workbench.ingress.tls.enable: "true"
   workbench.ingress.tls.cluster_issuer: "{{ default "" .Values.certmgr.cluster_issuer }}"
   workbench.ingress.tls.issuer: "{{ default "" .Values.certmgr.issuer }}"
-  workbench.ingress.tls.namespace: "{{ default "" .Values.certmgr.namespace }}"
 
   # Customize this instance of Workbench
   workbench.subdomain_prefix: "{{ .Values.workbench.subdomain_prefix }}"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -111,6 +111,8 @@ metadata:
   annotations:
     configHash: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
 spec:
+  strategy:
+    type: "{{ .Values.workbench.strategyType | default "RollingUpdate" }}"
   replicas: 1
   selector:
     matchLabels:
@@ -158,6 +160,11 @@ spec:
               configMapKeyRef:
                 name: {{ .Release.Name }}
                 key: workbench.domain
+          - name: COOKIEDOMAIN
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.cookie_domain
           - name: SUBDOMAIN_PREFIX
             valueFrom:
               configMapKeyRef:
@@ -189,10 +196,79 @@ spec:
 {{ else }}
             value: "$(DOMAIN)"
 {{ end }}
-          - name: NDSLABS_APISERVER_SERVICE_PORT
-            value: "30001"
+          - name: WORKBENCH_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.name
+          - name: WORKBENCH_LANDING_HTML
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.landing_html
+          - name: WORKBENCH_BRAND_LOGO_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.brand_logo_path
+          - name: WORKBENCH_FAVICON_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.favicon_path
+          - name: WORKBENCH_LEARNMORE_URL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.learn_more_url
           - name: APISERVER_PATH
             value: "/api"
+          - name: SHOW_CONFIG
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_config
+          - name: SHOW_LOGS
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_logs
+          - name: SHOW_CONSOLE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_console
+          - name: SHOW_REMOVE_SERVICE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_remove_service
+          - name: SHOW_EDIT_SERVICE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_edit_service
+          - name: SHOW_SERVICE_HELP_ICON
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_service_help_icon
+          - name: SHOW_CREATE_SPEC
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_create_spec
+          - name: SHOW_IMPORT_SPEC
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_import_spec
+          - name: SHOW_FILE_MANAGER
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_file_manager
+
         readinessProbe:
           httpGet:
             path: /asset/png/favicon-2-32x32.png

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -221,6 +221,11 @@ spec:
               configMapKeyRef:
                 name: {{ .Release.Name }}
                 key: workbench.learn_more_url
+          - name: WORKBENCH_HELP_LINKS
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.help_links
           - name: APISERVER_PATH
             value: "/api"
           - name: SHOW_CONFIG

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -118,13 +118,6 @@ spec:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ .Release.Name }}
-            port: 
-              number: 80
       - path: /ConfigModule.js
         pathType: Prefix
         backend:
@@ -133,6 +126,13 @@ spec:
             port: 
               number: 80
       - path: /swagger.yaml
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Release.Name }}
+            port: 
+              number: 80
+      - path: /env.json
         pathType: Prefix
         backend:
           service:
@@ -161,11 +161,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   rules:
-{{ if .Values.workbench.subdomain_prefix }}
-  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}
-{{ else }}
   - host: {{ .Values.workbench.domain }}
-{{ end }}
     http:
       paths:
       - backend:
@@ -175,6 +171,18 @@ spec:
               number: 80
         path: /
         pathType: Prefix
+{{ if .Values.workbench.subdomain_prefix }}
+  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Release.Name }}
+            port: 
+              number: 80
+        path: /
+        pathType: Prefix
+{{ end }}
   tls:
   - hosts:
     - {{ .Values.workbench.domain }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -6,10 +6,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-{{ if .Values.workbench.subdomain_prefix }}    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/cauth/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/login/"
-{{ else }}    nginx.ingress.kubernetes.io/auth-url: "https://{{ .Values.workbench.domain }}/cauth/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://{{ .Values.workbench.domain }}/login/"{{ end }}
+{{ if .Values.oauth.enabled | default false }}
+    nginx.ingress.kubernetes.io/auth-url: "{{ .Values.oauth.auth_url | default "https://$host/cauth/auth" }}"
+    nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.oauth.signin_url | default "https://$host/login/" }}"
+    nginx.ingress.kubernetes.io/auth-response-headers: "{{ .Values.oauth.auth_response_headers | default "x-auth-request-user, x-auth-request-email" }}"
+{{ else }}
+    nginx.ingress.kubernetes.io/auth-url: "https://$host/cauth/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://$host/login/"
+{{ end }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
@@ -17,9 +21,13 @@ spec:
   - hosts:
     - {{ .Values.workbench.domain }}
     - '*.{{ .Values.workbench.domain }}'
-    secretName: {{ .Values.tls.secretName }}-auth
+    secretName: {{ .Values.tls.secretName }}
   rules:
-{{ if .Values.workbench.subdomain_prefix }}  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}{{ else }}  - host: {{ .Values.workbench.domain }}{{ end }}
+{{ if .Values.workbench.subdomain_prefix }}
+  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}
+{{ else }}
+  - host: {{ .Values.workbench.domain }}
+{{ end }}
     http:
       paths:
       - path: /logs
@@ -44,6 +52,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/app-root: "/landing/"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
@@ -51,74 +60,65 @@ spec:
   - hosts:
     - {{ .Values.workbench.domain }}
     - '*.{{ .Values.workbench.domain }}'
+    secretName: {{ .Values.tls.secretName }}
   rules:
-{{ if .Values.workbench.subdomain_prefix }}  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}{{ else }}  - host: {{ .Values.workbench.domain }}{{ end }}
+{{ if .Values.workbench.subdomain_prefix }}
+  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}
+{{ else }}
+  - host: {{ .Values.workbench.domain }}
+{{ end }}
     http:
       paths:
-      - path: /api
+      - path: /api/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 30001
-      - path: /login
+      - path: /login/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /landing
+      - path: /landing/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /cauth
+      - path: /cauth/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /shared
+      - path: /shared/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /bower_components
+      - path: /node_modules/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /node_modules
+      - path: /asset/
         pathType: Prefix
         backend:
           service:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /asset
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ .Release.Name }}
-            port: 
-              number: 80
-      - path: /swagger.yaml
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ .Release.Name }}
-            port: 
-              number: 80
-      - path: /ConfigModule.js
+      - path: /
         pathType: Prefix
         backend:
           service:
@@ -131,15 +131,27 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
-{{ if .Values.certmgr.cluster_issuer }}    cert-manager.io/cluster-issuer: "{{ .Values.certmgr.cluster_issuer }}"{{ else if .Values.certmgr.issuer }}    cert-manager.io/issuer: "{{ .Values.certmgr.issuer }}"{{ end }}
+{{ if .Values.certmgr.cluster_issuer }}
+    cert-manager.io/cluster-issuer: "{{ .Values.certmgr.cluster_issuer }}"
+{{ else if .Values.certmgr.issuer }}
+    cert-manager.io/issuer: "{{ .Values.certmgr.issuer }}"
+{{ end }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-{{ if .Values.workbench.subdomain_prefix }}    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/landing/"{{ else }}    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.domain }}/landing/"{{ end }}
+{{ if .Values.workbench.subdomain_prefix }}
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/landing/"
+{{ else }}
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.domain }}/landing/"
+{{ end }}
   name: {{ .Release.Name }}-root
   namespace: {{ .Release.Namespace }}
 spec:
   rules:
-{{ if .Values.workbench.subdomain_prefix }}  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}{{ else }}  - host: {{ .Values.workbench.domain }}{{ end }}
+{{ if .Values.workbench.subdomain_prefix }}
+  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}
+{{ else }}
+  - host: {{ .Values.workbench.domain }}
+{{ end }}
     http:
       paths:
       - backend:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -125,6 +125,20 @@ spec:
             name: {{ .Release.Name }}
             port: 
               number: 80
+      - path: /ConfigModule.js
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Release.Name }}
+            port: 
+              number: 80
+      - path: /swagger.yaml
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Release.Name }}
+            port: 
+              number: 80
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Release.Name }}-auth
   namespace: {{ .Release.Namespace }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+#    kubernetes.io/ingress.class: "nginx"
 {{ if .Values.oauth.enabled | default false }}
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.oauth.auth_url | default "https://$host/cauth/auth" }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.oauth.signin_url | default "https://$host/login/" }}"
@@ -51,8 +51,8 @@ metadata:
   name: {{ .Release.Name }}-open
   namespace: {{ .Release.Namespace }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/app-root: "/landing/"
+#    kubernetes.io/ingress.class: "nginx"
+#    nginx.ingress.kubernetes.io/app-root: "/landing/"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
@@ -144,7 +144,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+#    kubernetes.io/ingress.class: "nginx"
 {{ if .Values.certmgr.cluster_issuer }}
     cert-manager.io/cluster-issuer: "{{ .Values.certmgr.cluster_issuer }}"
 {{ else if .Values.certmgr.issuer }}
@@ -152,6 +152,12 @@ metadata:
 {{ end }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+
+#    traefik.ingress.kubernetes.io/preserve-host: "true"
+#    traefik.ingress.kubernetes.io/redirect-permanent: "true"
+#    traefik.ingress.kubernetes.io/redirect-regex: "^https://(.*)"
+#    traefik.ingress.kubernetes.io/redirect-replacement: "https://www.$1"
+
 {{ if .Values.workbench.subdomain_prefix }}
     nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/landing/"
 {{ else }}
@@ -183,6 +189,49 @@ spec:
         path: /
         pathType: Prefix
 {{ end }}
+  tls:
+  - hosts:
+    - {{ .Values.workbench.domain }}
+    - '*.{{ .Values.workbench.domain }}'
+    secretName: {{ .Values.tls.secretName }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+#    kubernetes.io/ingress.class: "nginx"
+#{{ if .Values.certmgr.cluster_issuer }}
+#    cert-manager.io/cluster-issuer: "{{ .Values.certmgr.cluster_issuer }}"
+#{{ else if .Values.certmgr.issuer }}
+#    cert-manager.io/issuer: "{{ .Values.certmgr.issuer }}"
+#{{ end }}
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+
+    traefik.ingress.kubernetes.io/preserve-host: "true"
+    traefik.ingress.kubernetes.io/redirect-permanent: "true"
+    traefik.ingress.kubernetes.io/redirect-regex: "^https://(.*)"
+    traefik.ingress.kubernetes.io/redirect-replacement: "https://www.$1"
+
+{{ if .Values.workbench.subdomain_prefix }}
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/landing/"
+{{ else }}
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.domain }}/landing/"
+{{ end }}
+  name: {{ .Release.Name }}-www-redirect
+  namespace: {{ .Release.Namespace }}
+spec:
+  rules:
+  - host: {{ .Values.workbench.domain }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Release.Name }}
+            port: 
+              number: 80
+        path: /
+        pathType: Prefix
   tls:
   - hosts:
     - {{ .Values.workbench.domain }}

--- a/values.yaml
+++ b/values.yaml
@@ -45,16 +45,15 @@ workbench:
   timeout: 30
   inactivity_timeout: 480
 
-# FIXME: This has not been tested
 oauth:
   enabled: false
-  signin_url: ""
-  auth_url: ""
+  signin_url: "https://$host/login/"
+  auth_url: "https://$host/cauth/auth"
+  auth_response_headers: "x-auth-request-user, x-auth-request-email" # , x-auth-request-access-token, x-auth-request-redirect, x-auth-request-preferred-username"
 
 certmgr:
   cluster_issuer: "acmedns-issuer"
   issuer: ""
-  namespace: ""
 
 rbac:
   enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -7,6 +7,12 @@ workbench:
     enabled: false
     uisrc: ""
   name: "Labs Workbench"
+  landing_html: | 
+    <p>Labs Workbench is an environment where developers can prototype tools and capabilities that help build out the NDS framework and services.</p>
+    <p>In particular, it is a place that can host the development activities of <a href='http://www.nationaldataservice.org/projects/pilots.html'>NDS pilot projects.</a></p>
+  brand_logo_path: "../asset/png/favicon-32x32.png"
+  favicon_path: "../asset/png/favicon-16x16.png"
+  learn_more_url: "http://www.nationaldataservice.org/platform/workbench.html"
   domain: "local.ndslabs.org"
   subdomain_prefix: "www"
   volume_name: "global"
@@ -15,6 +21,7 @@ workbench:
   support_email: "ndslabs-support@nationaldataservice.org"
   analytics_tracking_id: ""
   require_account_approval: true
+  strategyType: "RollingUpdate"
   specs:
     repo: "https://github.com/nds-org/ndslabs-specs.git"
     branch: "master"
@@ -44,6 +51,18 @@ workbench:
     read_only: true
   timeout: 30
   inactivity_timeout: 480
+
+  # Enable optional UI features (default is true)
+  advanced_features:
+    show_config: true
+    show_logs: true
+    show_console: true
+    show_remove_service: true
+    show_edit_service: true
+    show_service_help_icon: true
+    show_create_spec: true
+    show_import_spec: true
+    show_file_manager: true
 
 oauth:
   enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -2,6 +2,118 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+frontend:
+  domain: "workbench.ndslabs.org"
+  subdomain_prefix: "www"
+  support_email: ""
+  analytics_tracking_id: ""
+  signin_url: "https://www.workbench.ndslabs.org/oauth2/start?rd=https%3A%2F%2Fwww.workbench.ndslabs.org%2Fmy-apps"
+  customization:
+    product_name: "Workbench"
+    landing_html: "<span style='font-size:20pt;'><p>Labs Workbench is an environment where developers can prototype tools and capabilities</p><p>that help build out the NDS framework and services. In particular, it is a place that can</p><p>host the development activities of <a style='text-decoration:none;' href='http://www.nationaldataservice.org/projects/pilots.html'>NDS pilot projects</a></p></span>"
+    favicon_path: "/favicon.svg"
+    brand_logo_path: "/favicon.svg"
+    learn_more_url: "http://www.nationaldataservice.org/platform/workbench.html"
+    help_links:
+      - icon": "fa-info-circle",
+        name": "Feature Overview",
+        url": "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Feature+Overview"
+      - icon": "fa-question-circle",
+        name": "FAQ",
+        url": "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Frequently+Asked+Questions"
+      - icon": "fa-book",
+        name": "User's Guide",
+        url": "https://nationaldataservice.atlassian.net/wiki/display/NDSC/User%27s+Guide"
+      - icon": "fa-code-fork",
+        name": "Developer's Guide",
+        url": "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Developer%27s+Guide"
+      - icon": "fa-gavel",
+        name": "Acceptable Use Policy",
+        url": "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Acceptable+Use+Policy"
+
+backend:
+  timeout: 30
+  inactivity_timeout: 480
+  specs:
+    repo: "https://github.com/nds-org/ndslabs-specs.git"
+    branch: master
+  storage:
+    home:
+      storage_class: "nfs-condo"
+      claim_suffix: "-home"
+    shared:
+      enabled: false
+      volume_path: "/tmp/shared"
+      storage_class: "nfs-condo"
+      read_only: true
+  smtp:
+    # Specify host/port to use standalone SMTP
+    host: # smtp.your.edu
+    port: # 25
+    # Specify user/pass to use Gmail SMTP
+    gmail_user: 
+    gmail_pass: 
+
+
+
+controller:
+  kind: Deployment
+  labels:
+    app: workbench
+  images:
+    etcd: "quay.io/coreos/etcd:v3.3"
+    webui: "ndslabs/webui:react"
+    apiserver: "ndslabs/apiserver:cddr"
+  strategy_type: "RollingUpdate"
+
+ingress:
+  tls:
+    enabled: true
+    hosts:
+      - "*.workbench.ndslabs.org"
+      - "www.workbench.ndslabs.org"
+    secretName: "ndslabs-tls"
+  root:
+    annotations:
+      cluster_issuer: "acmedns-issuer"
+      issuer: ""
+  workbench:
+    annotations: {}
+      
+  
+  userapps:
+    annotations:
+      # kubernetes.io/ingress.class: "traefik"
+      signin_url: "https://www.workbench.ndslabs.org/oauth2/start?rd=https%3A%2F%2Fwww.workbench.ndslabs.org%2Fmy-apps"
+      auth_url: "https://www.workbench.ndslabs.org/oauth2/auth"
+      auth_response_headers: "x-auth-request-user, x-auth-request-email, x-auth-request-access-token, x-auth-request-redirect, x-auth-request-preferred-username"
+  
+
+### TODO
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+
+
+#### LEGACY
+
+
 workbench:
   dev:
     enabled: false
@@ -13,6 +125,7 @@ workbench:
   brand_logo_path: "../asset/png/favicon-32x32.png"
   favicon_path: "../asset/png/favicon-16x16.png"
   learn_more_url: "http://www.nationaldataservice.org/platform/workbench.html"
+  help_links: "[{ \"name\": \"Feature Overview\", \"icon\": \"fa-info-circle\", \"url\": \"https://nationaldataservice.atlassian.net/wiki/display/NDSC/Feature+Overview\" },{ \"name\": \"F.A.Q.\", \"icon\": \"fa-question-circle\", \"url\": \"https://nationaldataservice.atlassian.net/wiki/display/NDSC/Frequently+Asked+Questions\"}, { \"name\": \"User's Guide\",           icon: \"fa-book\", \"url\": \"https://nationaldataservice.atlassian.net/wiki/display/NDSC/User%27s+Guide\" }, { \"name\": \"Developer's Guide\", \"icon\": \"fa-code-fork\", \"url\": \"https://nationaldataservice.atlassian.net/wiki/display/NDSC/Developer%27s+Guide\" },{ \"name\": \"Acceptable Use Policy\",  \"icon\": \"fa-gavel\", \"url\": \"https://nationaldataservice.atlassian.net/wiki/display/NDSC/Acceptable+Use+Policy\" }]"
   domain: "local.ndslabs.org"
   subdomain_prefix: "www"
   volume_name: "global"


### PR DESCRIPTION
* Remove duplicate /dashboard ingress path

This fixes /cauth and SSO with oauth2-proxy

* Enable OAuth2 configuration via Helm chart values.yaml

* Simplify ingress configuration considerably

* Expose admin port internally if oauth enabled

* Fix auth-repsonse-headers annotation name, fix hard-coded secret name

* Fix default values.yaml entry for auth_response_headers

* Remove port mapping for 30002

Added a secure endpoint that can run on the usual 30001 instead

* Include root Ingress (where did this go??)