### PR TITLE
Parameterize ProductName and ProductLandingHtml for the webui

### DIFF
--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -16,6 +16,8 @@ data:
   workbench.subdomain_prefix: "{{ .Values.workbench.subdomain_prefix }}"
   workbench.domain: "{{ .Values.workbench.domain }}"
   workbench.name: "{{ .Values.workbench.name }}"
+  workbench.landing_html: | 
+    {{ .Values.workbench.landing_html | quote}}
   workbench.support_email: "{{ .Values.workbench.support_email }}"
   workbench.analytics_tracking_id: "{{ .Values.workbench.analytics_tracking_id }}"
   workbench.node_selector_name: "{{ .Values.workbench.node_selector_name }}"

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -20,6 +20,7 @@ data:
     {{ .Values.workbench.landing_html | quote }}
   workbench.brand_logo_path: {{ .Values.workbench.brand_logo | quote }}
   workbench.favicon_path: {{ .Values.workbench.favicon | quote }}
+  workbench.learn_more_url: {{ .Values.workbench.learn_more_url | quote }}
   workbench.support_email: "{{ .Values.workbench.support_email }}"
   workbench.analytics_tracking_id: "{{ .Values.workbench.analytics_tracking_id }}"
   workbench.node_selector_name: "{{ .Values.workbench.node_selector_name }}"

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -18,8 +18,8 @@ data:
   workbench.name: "{{ .Values.workbench.name }}"
   workbench.landing_html: | 
     {{ .Values.workbench.landing_html | quote }}
-  workbench.brand_logo_path: {{ .Values.workbench.brand_logo | quote }}
-  workbench.favicon_path: {{ .Values.workbench.favicon | quote }}
+  workbench.brand_logo_path: {{ .Values.workbench.brand_logo_path | quote }}
+  workbench.favicon_path: {{ .Values.workbench.favicon_path | quote }}
   workbench.support_email: "{{ .Values.workbench.support_email }}"
   workbench.analytics_tracking_id: "{{ .Values.workbench.analytics_tracking_id }}"
   workbench.node_selector_name: "{{ .Values.workbench.node_selector_name }}"

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -15,9 +15,20 @@ data:
   # Customize this instance of Workbench
   workbench.subdomain_prefix: "{{ .Values.workbench.subdomain_prefix }}"
   workbench.domain: "{{ .Values.workbench.domain }}"
+  workbench.cookie_domain: "{{ .Values.workbench.domain }}"
+
+  workbench.advanced_features.show_config: "{{ .Values.workbench.advanced_features.show_config }}"
+  workbench.advanced_features.show_logs: "{{ .Values.workbench.advanced_features.show_logs }}"
+  workbench.advanced_features.show_console: "{{ .Values.workbench.advanced_features.show_console }}"
+  workbench.advanced_features.show_service_help_icon: "{{ .Values.workbench.advanced_features.show_service_help_icon }}"
+  workbench.advanced_features.show_edit_service: "{{ .Values.workbench.advanced_features.show_edit_service }}"
+  workbench.advanced_features.show_remove_service: "{{ .Values.workbench.advanced_features.show_remove_service }}"
+  workbench.advanced_features.show_create_spec: "{{ .Values.workbench.advanced_features.show_create_spec }}"
+  workbench.advanced_features.show_import_spec: "{{ .Values.workbench.advanced_features.show_import_spec }}"
+  workbench.advanced_features.show_file_manager: "{{ .Values.workbench.advanced_features.show_file_manager }}"
+
   workbench.name: "{{ .Values.workbench.name }}"
-  workbench.landing_html: | 
-    {{ .Values.workbench.landing_html | quote }}
+  workbench.landing_html: {{ .Values.workbench.landing_html | quote }}
   workbench.brand_logo_path: {{ .Values.workbench.brand_logo_path | quote }}
   workbench.favicon_path: {{ .Values.workbench.favicon_path | quote }}
   workbench.learn_more_url: {{ .Values.workbench.learn_more_url | quote }}

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -17,7 +17,9 @@ data:
   workbench.domain: "{{ .Values.workbench.domain }}"
   workbench.name: "{{ .Values.workbench.name }}"
   workbench.landing_html: | 
-    {{ .Values.workbench.landing_html | quote}}
+    {{ .Values.workbench.landing_html | quote }}
+  workbench.brand_logo_path: {{ .Values.workbench.brand_logo | quote }}
+  workbench.favicon_path: {{ .Values.workbench.favicon | quote }}
   workbench.support_email: "{{ .Values.workbench.support_email }}"
   workbench.analytics_tracking_id: "{{ .Values.workbench.analytics_tracking_id }}"
   workbench.node_selector_name: "{{ .Values.workbench.node_selector_name }}"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -111,6 +111,8 @@ metadata:
   annotations:
     configHash: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
 spec:
+  strategy:
+    type: "{{ .Values.workbench.strategyType | default "RollingUpdate" }}"
   replicas: 1
   selector:
     matchLabels:
@@ -189,10 +191,37 @@ spec:
 {{ else }}
             value: "$(DOMAIN)"
 {{ end }}
-          - name: NDSLABS_APISERVER_SERVICE_PORT
-            value: "30001"
+          - name: PRODUCT_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.product_name
+          - name: PRODUCT_LANDING_HTML
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.product_landing_html
           - name: APISERVER_PATH
             value: "/api"
+          - name: SHOW_CONFIG
+            value: "{{ .Values.workbench.advanced_features.show_config | default true }}"
+          - name: SHOW_LOGS
+            value: "{{ .Values.workbench.advanced_features.show_logs | default true }}"
+          - name: SHOW_CONSOLE
+            value: "{{ .Values.workbench.advanced_features.show_console | default true }}"
+          - name: SHOW_REMOVE_SERVICE
+            value: "{{ .Values.workbench.advanced_features.show_remove_service | default true }}"
+          - name: SHOW_EDIT_SERVICE
+            value: "{{ .Values.workbench.advanced_features.show_edit_service | default true }}"
+          - name: SHOW_SERVICE_HELP_ICON
+            value: "{{ .Values.workbench.advanced_features.show_service_help_icon | default true }}"
+          - name: SHOW_CREATE_SPEC
+            value: "{{ .Values.workbench.advanced_features.show_create_spec | default true }}"
+          - name: SHOW_IMPORT_SPEC
+            value: "{{ .Values.workbench.advanced_features.show_import_spec | default true }}"
+          - name: SHOW_FILE_MANAGER
+            value: "{{ .Values.workbench.advanced_features.show_file_manager | default true }}"
+
         readinessProbe:
           httpGet:
             path: /asset/png/favicon-2-32x32.png

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -191,16 +191,26 @@ spec:
 {{ else }}
             value: "$(DOMAIN)"
 {{ end }}
-          - name: PRODUCT_NAME
+          - name: WORKBENCH_NAME
             valueFrom:
               configMapKeyRef:
                 name: {{ .Release.Name }}
                 key: workbench.name
-          - name: PRODUCT_LANDING_HTML
+          - name: WORKBENCH_LANDING_HTML
             valueFrom:
               configMapKeyRef:
                 name: {{ .Release.Name }}
-                key: workbench.product_landing_html
+                key: workbench.landing_html
+          - name: WORKBENCH_BRAND_LOGO
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.brand_logo_path
+          - name: WORKBENCH_FAVICON_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.favicon_path
           - name: APISERVER_PATH
             value: "/api"
           - name: SHOW_CONFIG

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -195,7 +195,7 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: {{ .Release.Name }}
-                key: workbench.product_name
+                key: workbench.name
           - name: PRODUCT_LANDING_HTML
             valueFrom:
               configMapKeyRef:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -201,7 +201,7 @@ spec:
               configMapKeyRef:
                 name: {{ .Release.Name }}
                 key: workbench.landing_html
-          - name: WORKBENCH_BRAND_LOGO
+          - name: WORKBENCH_BRAND_LOGO_PATH
             valueFrom:
               configMapKeyRef:
                 name: {{ .Release.Name }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -211,6 +211,11 @@ spec:
               configMapKeyRef:
                 name: {{ .Release.Name }}
                 key: workbench.favicon_path
+          - name: WORKBENCH_LEARNMORE_URL
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.learn_more_url
           - name: APISERVER_PATH
             value: "/api"
           - name: SHOW_CONFIG

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -160,6 +160,11 @@ spec:
               configMapKeyRef:
                 name: {{ .Release.Name }}
                 key: workbench.domain
+          - name: COOKIEDOMAIN
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.cookie_domain
           - name: SUBDOMAIN_PREFIX
             valueFrom:
               configMapKeyRef:
@@ -219,23 +224,50 @@ spec:
           - name: APISERVER_PATH
             value: "/api"
           - name: SHOW_CONFIG
-            value: "{{ .Values.workbench.advanced_features.show_config | default true }}"
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_config
           - name: SHOW_LOGS
-            value: "{{ .Values.workbench.advanced_features.show_logs | default true }}"
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_logs
           - name: SHOW_CONSOLE
-            value: "{{ .Values.workbench.advanced_features.show_console | default true }}"
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_console
           - name: SHOW_REMOVE_SERVICE
-            value: "{{ .Values.workbench.advanced_features.show_remove_service | default true }}"
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_remove_service
           - name: SHOW_EDIT_SERVICE
-            value: "{{ .Values.workbench.advanced_features.show_edit_service | default true }}"
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_edit_service
           - name: SHOW_SERVICE_HELP_ICON
-            value: "{{ .Values.workbench.advanced_features.show_service_help_icon | default true }}"
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_service_help_icon
           - name: SHOW_CREATE_SPEC
-            value: "{{ .Values.workbench.advanced_features.show_create_spec | default true }}"
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_create_spec
           - name: SHOW_IMPORT_SPEC
-            value: "{{ .Values.workbench.advanced_features.show_import_spec | default true }}"
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_import_spec
           - name: SHOW_FILE_MANAGER
-            value: "{{ .Values.workbench.advanced_features.show_file_manager | default true }}"
+            valueFrom:
+              configMapKeyRef:
+                name: {{ .Release.Name }}
+                key: workbench.advanced_features.show_file_manager
 
         readinessProbe:
           httpGet:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -132,6 +132,13 @@ spec:
             name: {{ .Release.Name }}
             port: 
               number: 80
+      - path: /env.json
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Release.Name }}
+            port: 
+              number: 80
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -154,11 +161,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   rules:
-{{ if .Values.workbench.subdomain_prefix }}
-  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}
-{{ else }}
   - host: {{ .Values.workbench.domain }}
-{{ end }}
     http:
       paths:
       - backend:
@@ -168,6 +171,18 @@ spec:
               number: 80
         path: /
         pathType: Prefix
+{{ if .Values.workbench.subdomain_prefix }}
+  - host: {{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Release.Name }}
+            port: 
+              number: 80
+        path: /
+        pathType: Prefix
+{{ end }}
   tls:
   - hosts:
     - {{ .Values.workbench.domain }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -118,13 +118,6 @@ spec:
             name: {{ .Release.Name }}
             port: 
               number: 80
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ .Release.Name }}
-            port: 
-              number: 80
       - path: /ConfigModule.js
         pathType: Prefix
         backend:

--- a/values.yaml
+++ b/values.yaml
@@ -10,6 +10,8 @@ workbench:
   landing_html: | 
     <p>Labs Workbench is an environment where developers can prototype tools and capabilities that help build out the NDS framework and services.</p>
     <p>In particular, it is a place that can host the development activities of <a href='http://www.nationaldataservice.org/projects/pilots.html'>NDS pilot projects.</a></p>
+  brand_logo_path: "../asset/png/favicon-32x32.png"
+  favicon_path: "../asset/png/favicon-16x16.png"
   domain: "local.ndslabs.org"
   subdomain_prefix: "www"
   volume_name: "global"

--- a/values.yaml
+++ b/values.yaml
@@ -12,6 +12,7 @@ workbench:
     <p>In particular, it is a place that can host the development activities of <a href='http://www.nationaldataservice.org/projects/pilots.html'>NDS pilot projects.</a></p>
   brand_logo_path: "../asset/png/favicon-32x32.png"
   favicon_path: "../asset/png/favicon-16x16.png"
+  learn_more_url: "http://www.nationaldataservice.org/platform/workbench.html"
   domain: "local.ndslabs.org"
   subdomain_prefix: "www"
   volume_name: "global"

--- a/values.yaml
+++ b/values.yaml
@@ -7,6 +7,9 @@ workbench:
     enabled: false
     uisrc: ""
   name: "Labs Workbench"
+  landing_html: | 
+    <p>Labs Workbench is an environment where developers can prototype tools and capabilities that help build out the NDS framework and services.</p>
+    <p>In particular, it is a place that can host the development activities of <a href='http://www.nationaldataservice.org/projects/pilots.html'>NDS pilot projects.</a></p>
   domain: "local.ndslabs.org"
   subdomain_prefix: "www"
   volume_name: "global"
@@ -15,6 +18,7 @@ workbench:
   support_email: "ndslabs-support@nationaldataservice.org"
   analytics_tracking_id: ""
   require_account_approval: true
+  strategyType: "RollingUpdate"
   specs:
     repo: "https://github.com/nds-org/ndslabs-specs.git"
     branch: "master"
@@ -44,6 +48,18 @@ workbench:
     read_only: true
   timeout: 30
   inactivity_timeout: 480
+
+  # Enable optional UI features (default is true)
+  advanced_features:
+    show_config: true
+    show_logs: true
+    show_console: true
+    show_remove_service: true
+    show_edit_service: true
+    show_service_help_icon: true
+    show_create_spec: true
+    show_import_spec: true
+    show_file_manager: true
 
 oauth:
   enabled: false


### PR DESCRIPTION
## Problem
Customize Landing Text / Product Name is painful on first setup - currently involves forking, editing, and redeploying.

## Approach
* Parameterize the Landing Text and Product Name in the Helm chart `values.yaml`
* Full chain: values.yaml => ConfigMap => Deployment

## How to Test
Prerequisites: Helm chart deployed previously, deploy https://github.com/nds-org/ndslabs/pull/346 as `webui` Docker image

1. Modify Helm chart values to set the following for `workbench.images.webui`: `ndslabs/angular-ui:parameterize-product-name-and-landing-text`
2. Modify Helm chart values to set the following additional UI customizations:
```yaml
   name: "HelloWorld"
   landing_html: |
    <p>This is an example Landing Page</p>
    <p>You can customize the page with any HTML. You can even add <a href='https://google.com'>links!</a></p>
``` 
3. Deploy the Helm chart with the new values
4. Wait for Pod to finish restarting (delete the Pod, if needed)
5. Navigate to the landing page
    * You should see the product name and landing HTML that you specified in the Helm chart appear in the UI