### PR TITLE
feat: support traefik ingress

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Release.Name }}-auth
   namespace: {{ .Release.Namespace }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+#    kubernetes.io/ingress.class: "nginx"
 {{ if .Values.oauth.enabled | default false }}
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.oauth.auth_url | default "https://$host/cauth/auth" }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.oauth.signin_url | default "https://$host/login/" }}"
@@ -51,8 +51,8 @@ metadata:
   name: {{ .Release.Name }}-open
   namespace: {{ .Release.Namespace }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/app-root: "/landing/"
+#    kubernetes.io/ingress.class: "nginx"
+#    nginx.ingress.kubernetes.io/app-root: "/landing/"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
@@ -144,7 +144,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+#    kubernetes.io/ingress.class: "nginx"
 {{ if .Values.certmgr.cluster_issuer }}
     cert-manager.io/cluster-issuer: "{{ .Values.certmgr.cluster_issuer }}"
 {{ else if .Values.certmgr.issuer }}
@@ -152,6 +152,12 @@ metadata:
 {{ end }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
+
+#    traefik.ingress.kubernetes.io/preserve-host: "true"
+#    traefik.ingress.kubernetes.io/redirect-permanent: "true"
+#    traefik.ingress.kubernetes.io/redirect-regex: "^https://(.*)"
+#    traefik.ingress.kubernetes.io/redirect-replacement: "https://www.$1"
+
 {{ if .Values.workbench.subdomain_prefix }}
     nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/landing/"
 {{ else }}
@@ -183,6 +189,49 @@ spec:
         path: /
         pathType: Prefix
 {{ end }}
+  tls:
+  - hosts:
+    - {{ .Values.workbench.domain }}
+    - '*.{{ .Values.workbench.domain }}'
+    secretName: {{ .Values.tls.secretName }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+#    kubernetes.io/ingress.class: "nginx"
+#{{ if .Values.certmgr.cluster_issuer }}
+#    cert-manager.io/cluster-issuer: "{{ .Values.certmgr.cluster_issuer }}"
+#{{ else if .Values.certmgr.issuer }}
+#    cert-manager.io/issuer: "{{ .Values.certmgr.issuer }}"
+#{{ end }}
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+
+    traefik.ingress.kubernetes.io/preserve-host: "true"
+    traefik.ingress.kubernetes.io/redirect-permanent: "true"
+    traefik.ingress.kubernetes.io/redirect-regex: "^https://(.*)"
+    traefik.ingress.kubernetes.io/redirect-replacement: "https://www.$1"
+
+{{ if .Values.workbench.subdomain_prefix }}
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.subdomain_prefix }}.{{ .Values.workbench.domain }}/landing/"
+{{ else }}
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://{{ .Values.workbench.domain }}/landing/"
+{{ end }}
+  name: {{ .Release.Name }}-www-redirect
+  namespace: {{ .Release.Namespace }}
+spec:
+  rules:
+  - host: {{ .Values.workbench.domain }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Release.Name }}
+            port: 
+              number: 80
+        path: /
+        pathType: Prefix
   tls:
   - hosts:
     - {{ .Values.workbench.domain }}


### PR DESCRIPTION
## Problem
Helm chart has hard-coded annotations for NGINX

## Approach
Remove hard-coded `nginx` ingress class to potentially support other ingress types