### PR TITLE
Add a liveness probe to apiserver container

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -283,6 +283,16 @@ spec:
           timeoutSeconds: 120
 
       - name: apiserver
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /api/healthz
+            port: 30001
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
         image: {{ required "Must specify an image for ndslabs-apiserver" .Values.workbench.images.apiserver }}
         imagePullPolicy: Always
         securityContext:


### PR DESCRIPTION
## Problem
There is an odd recurring issue that seems to happen sporadically (e.g. once every few months) where the API server becomes semi-responsive. During this time, the apiserver appears to have lost its ability to communicate with the Kubernetes API server.

Fixes #30

The effective workaround has been to kill the pod, but the behavior is subtle enough that it evades our current health checking.

The problem, however, is very obvious when looking at the `apiserver` logs, which look as follows:
```bash
E1004 12:38:23.444390      29 reflector.go:205] github.com/ndslabs/apiserver/pkg/kube/kube.go:765: Failed to list *v1.Pod: Get "https://10.96.0.1:443/api/v1/pods?limit=500&resourceVersion=0": http2: no cached connection was available
E1004 12:38:24.443896      29 reflector.go:205] github.com/ndslabs/apiserver/pkg/kube/kube.go:791: Failed to list *v1.ReplicationController: Get "https://10.96.0.1:443/api/v1/replicationcontrollers?limit=500&resourceVersion=0": http2: no cached connection was available
E1004 12:38:24.444699      29 reflector.go:205] github.com/ndslabs/apiserver/pkg/kube/kube.go:765: Failed to list *v1.Pod: Get "https://10.96.0.1:443/api/v1/pods?limit=500&resourceVersion=0": http2: no cached connection was available
E1004 12:38:25.444302      29 reflector.go:205] github.com/ndslabs/apiserver/pkg/kube/kube.go:791: Failed to list *v1.ReplicationController: Get "https://10.96.0.1:443/api/v1/replicationcontrollers?limit=500&resourceVersion=0": http2: no cached connection was available
E1004 12:38:25.445315      29 reflector.go:205] github.com/ndslabs/apiserver/pkg/kube/kube.go:765: Failed to list *v1.Pod: Get "https://10.96.0.1:443/api/v1/pods?limit=500&resourceVersion=0": http2: no cached connection was available
E1004 12:38:26.444732      29 reflector.go:205] github.com/ndslabs/apiserver/pkg/kube/kube.go:791: Failed to list *v1.ReplicationController: Get "https://10.96.0.1:443/api/v1/replicationcontrollers?limit=500&resourceVersion=0": http2: no cached connection was available
E1004 12:38:26.445582      29 reflector.go:205] github.com/ndslabs/apiserver/pkg/kube/kube.go:765: Failed to list *v1.Pod: Get "https://10.96.0.1:443/api/v1/pods?limit=500&resourceVersion=0": http2: no cached connection was available
E1004 12:38:27.445138      29 reflector.go:205] github.com/ndslabs/apiserver/pkg/kube/kube.go:791: Failed to list *v1.ReplicationController: Get "https://10.96.0.1:443/api/v1/replicationcontrollers?limit=500&resourceVersion=0": http2: no cached connection was available
E1004 12:38:27.446069      29 reflector.go:205] github.com/ndslabs/apiserver/pkg/kube/kube.go:765: Failed to list *v1.Pod: Get "https://10.96.0.1:443/api/v1/pods?limit=500&resourceVersion=0": http2: no cached connection was available
E1004 12:38:28.445722      29 reflector.go:205] github.com/ndslabs/apiserver/pkg/kube/kube.go:791: Failed to list *v1.ReplicationController: Get "https://10.96.0.1:443/api/v1/replicationcontrollers?limit=500&resourceVersion=0": http2: no cached connection was available
E1004 12:38:28.446701      29 reflector.go:205] github.com/ndslabs/apiserver/pkg/kube/kube.go:765: Failed to list *v1.Pod: Get "https://10.96.0.1:443/api/v1/pods?limit=500&resourceVersion=0": http2: no cached connection was available
E1004 12:38:29.446354      29 reflector.go:205] github.com/ndslabs/apiserver/pkg/kube/kube.go:791: Failed to list *v1.ReplicationController: Get "https://10.96.0.1:443/api/v1/replicationcontrollers?limit=500&resourceVersion=0": http2: no cached connection was available
```

## Approach
As it is unclear when/why the connection to Kubernetes API, but adding a liveness probe should (at the very least) kill the API server pod if/when this behavior is detected in the future.