### PR TITLE
Added ingressClass variable to values.yaml, fix YAML errors

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Release.Name }}-auth
   namespace: {{ .Release.Namespace }}
   annotations:
-#    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: {{ .Values.workbench.ingress_class | quote }}
 {{ if .Values.oauth.enabled | default false }}
     nginx.ingress.kubernetes.io/auth-url: "{{ .Values.oauth.auth_url | default "https://$host/cauth/auth" }}"
     nginx.ingress.kubernetes.io/auth-signin: "{{ .Values.oauth.signin_url | default "https://$host/login/" }}"
@@ -51,8 +51,8 @@ metadata:
   name: {{ .Release.Name }}-open
   namespace: {{ .Release.Namespace }}
   annotations:
-#    kubernetes.io/ingress.class: "nginx"
-#    nginx.ingress.kubernetes.io/app-root: "/landing/"
+    kubernetes.io/ingress.class: {{ .Values.workbench.ingress_class | quote }}
+    nginx.ingress.kubernetes.io/app-root: "/landing/"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
@@ -144,7 +144,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-#    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: {{ .Values.workbench.ingress_class | quote }}
 {{ if .Values.certmgr.cluster_issuer }}
     cert-manager.io/cluster-issuer: "{{ .Values.certmgr.cluster_issuer }}"
 {{ else if .Values.certmgr.issuer }}
@@ -199,12 +199,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-#    kubernetes.io/ingress.class: "nginx"
-#{{ if .Values.certmgr.cluster_issuer }}
-#    cert-manager.io/cluster-issuer: "{{ .Values.certmgr.cluster_issuer }}"
-#{{ else if .Values.certmgr.issuer }}
-#    cert-manager.io/issuer: "{{ .Values.certmgr.issuer }}"
-#{{ end }}
+    kubernetes.io/ingress.class: {{ .Values.workbench.ingress_class | quote }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
 

--- a/values.yaml
+++ b/values.yaml
@@ -63,8 +63,8 @@ controller:
     app: workbench
   images:
     etcd: "quay.io/coreos/etcd:v3.3"
-    webui: "ndslabs/angular-ui:1.3.0"
-    apiserver: "ndslabs/apiserver:1.3.0"
+    webui: "ndslabs/angular-ui:1.3.1"
+    apiserver: "ndslabs/apiserver:1.3.1"
   strategy_type: "RollingUpdate"
 
 ingress:
@@ -141,8 +141,8 @@ workbench:
     repo: "https://github.com/nds-org/ndslabs-specs.git"
     branch: "master"
   images:
-    webui: "ndslabs/angular-ui:1.3.0"
-    apiserver: "ndslabs/apiserver:1.3.0"
+    webui: "ndslabs/angular-ui:1.3.1"
+    apiserver: "ndslabs/apiserver:1.3.1"
     etcd: "quay.io/coreos/etcd:v3.3"
     smtp: "namshi/smtp:latest"
   etcd_storage:

--- a/values.yaml
+++ b/values.yaml
@@ -16,21 +16,21 @@ frontend:
     brand_logo_path: "/favicon.svg"
     learn_more_url: "http://www.nationaldataservice.org/platform/workbench.html"
     help_links:
-      - icon": "fa-info-circle",
-        name": "Feature Overview",
-        url": "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Feature+Overview"
-      - icon": "fa-question-circle",
-        name": "FAQ",
-        url": "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Frequently+Asked+Questions"
-      - icon": "fa-book",
-        name": "User's Guide",
-        url": "https://nationaldataservice.atlassian.net/wiki/display/NDSC/User%27s+Guide"
-      - icon": "fa-code-fork",
-        name": "Developer's Guide",
-        url": "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Developer%27s+Guide"
-      - icon": "fa-gavel",
-        name": "Acceptable Use Policy",
-        url": "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Acceptable+Use+Policy"
+      - icon: "fa-info-circle"
+        name: "Feature Overview"
+        url: "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Feature+Overview"
+      - icon: "fa-question-circle"
+        name: "FAQ"
+        url: "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Frequently+Asked+Questions"
+      - icon: "fa-book"
+        name: "User's Guide"
+        url: "https://nationaldataservice.atlassian.net/wiki/display/NDSC/User%27s+Guide"
+      - icon: "fa-code-fork"
+        name: "Developer's Guide"
+        url: "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Developer%27s+Guide"
+      - icon: "fa-gavel"
+        name: "Acceptable Use Policy"
+        url: "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Acceptable+Use+Policy"
 
 backend:
   timeout: 30
@@ -120,9 +120,10 @@ workbench:
     enabled: false
     uisrc: ""
   name: "Labs Workbench"
-  landing_html: | 
+  landing_html: >-
     <p>Labs Workbench is an environment where developers can prototype tools and capabilities that help build out the NDS framework and services.</p>
     <p>In particular, it is a place that can host the development activities of <a href='http://www.nationaldataservice.org/projects/pilots.html'>NDS pilot projects.</a></p>
+  ingress_class: "nginx"
   brand_logo_path: "../asset/png/favicon-32x32.png"
   favicon_path: "../asset/png/favicon-16x16.png"
   learn_more_url: "http://www.nationaldataservice.org/platform/workbench.html"


### PR DESCRIPTION
## Problem
The default `values.yaml` has significant format issues that are not easy to diagnose

## Approach
* Fix formatting errors in YAML
  * Removed extra chars from V2.help_links (`,`, `"`, etc)
  * Use `>-` helper (instead of `|`) to more properly escape the `landing_html`
* Parameterize IngressClass, as this annotation is now required by NGINX but optional for Traefik
* Bring back `app-root` annotation, to avoid potential clash between ingress routes
* Roll versions forward to 1.3.1