### PR TITLE
fix: issues reported by helm lint

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,8 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "2.0.0"
 description: A Helm chart for running the NDS Labs Workbench under Kubernetes
 name: workbench
+icon: https://github.com/nds-org/ndslabs-specs/raw/2.0.0/system/ndslabs-badge.png
 version: 1.4.0
 
 # Dependencies for workbench. Some of the dependencies are only installed if they


### PR DESCRIPTION
## Problem
`helm lint` reports errors:
```
==> Linting .
[INFO] Chart.yaml: icon is recommended
[ERROR] Chart.yaml: dependencies are not valid in the Chart file with apiVersion 'v1'. They are valid in apiVersion 'v2'

Error: 1 chart(s) linted, 1 chart(s) failed
```

## Approach
* Add an `icon`
* Roll `apiVersion` forward to `v2`