### PR TITLE
Revert "chore: remove livereload variant (not needed)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ define HELP_BODY
           - `make dep` to pull Helm dependency subcharts
           - `make template` to perform a dry-run of Helm chart generation (for debugging)
           - `make` or `make install` to perform Helm install and/or upgrade with default values (optionally includes `make realm_import_secret`, enabled by default)
-          - `make local` or `make dev` to use localdev values (optionally includes `make realm_import_secret`, enabled by default)
+          - `make local` to use localdev values (optionally includes `make realm_import_secret`, enabled by default)
+          - `make dev` to use localdev values and live reload enabled (optionally includes `make realm_import_secret`, enabled by default)
           - `make status` or `make watch` to check status or watch for changes to Pods
           - `make describe` to check Pod events for startup errors
           - `make target=api logs` or `make target=proxy logs` to check Pod logs for runtime errors
@@ -126,13 +127,15 @@ install: check_required
 	if [ "$(REALM_IMPORT)" == "true" ]; then make realm_import_secret; helm upgrade --install -n $(NAMESPACE) $(NAME) --create-namespace $(CHART_PATH) -f values.realmimport.yaml; fi
 
 # Install using defaults + values.localdev.yaml
-local: check_required clone compile
+local: check_required clone
 	if [ ! -d "charts/" ]; then make dep; fi
 	if [ "$(REALM_IMPORT)" != "true" ]; then helm upgrade --install -n $(NAMESPACE) $(NAME) --create-namespace $(CHART_PATH) -f values.localdev.yaml; fi
 	if [ "$(REALM_IMPORT)" == "true" ]; then make realm_import_secret; helm upgrade --install -n $(NAMESPACE) $(NAME) --create-namespace $(CHART_PATH) -f values.localdev.yaml -f values.realmimport.yaml; fi
 
-# Alias for make local
-dev: local
+# Install using defaults + localdev + values.localdev.livereload.yaml
+dev: check_required dep clone compile
+	if [ "$(REALM_IMPORT)" != "true" ]; then helm upgrade --install $(NAME) -n $(NAMESPACE) $(CHART_PATH) --create-namespace -f values.localdev.yaml -f values.localdev.livereload.yaml; fi
+	if [ "$(REALM_IMPORT)" == "true" ]; then make realm_import_secret; helm upgrade --install $(NAME) -n $(NAMESPACE) $(CHART_PATH) --create-namespace -f values.localdev.yaml -f values.localdev.livereload.yaml -f values.realmimport.yaml; fi
 
 uninstall: check_helm 
 	helm uninstall --wait -n $(NAMESPACE) $(NAME)
@@ -160,10 +163,12 @@ compile: check_yarn
 	(cd src/webui/ && yarn install && yarn build)
 
 build: check_docker clone
+	docker build -t $(WEBUI_IMAGE)-live -f src/webui/Dockerfile.dev src/webui/
 	docker build -t $(APISERVER_IMAGE) src/apiserver/
 	docker build -t $(WEBUI_IMAGE) src/webui/
 
 push: build
+	docker push $(WEBUI_IMAGE)-live
 	docker push $(APISERVER_IMAGE)
 	docker push $(WEBUI_IMAGE)
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ These options affect the internals of Workbench and the customization of the Web
 | Path | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
 | `config.frontend.domain` | string | Domain name (used by backend for self-reference) | `https://changeme.ndslabs.org` |
+| `config.frontend.live_reload` | bool | If true, change to use dev image ports (instead of port 80) when running dev image | `false` |
 | `config.frontend.signin_url` | string | URL to route frontend requests to "Log In"  | `https://changeme.ndslabs.org/oauth2/start?rd=https%3A%2F%2Fkubernetes.docker.internal%2Fmy-apps` |
 | `config.frontend.signout_url` | string | URL to route frontend requests to "Log Out"  | `https://changeme.ndslabs.org/oauth2/sign_out?rd=https%3A%2F%2Fkubernetes.docker.internal%2F` |
 | `config.frontend.customization.product_name` | string | Human-friendly name to use for this product in the navbar | `Workbench` |
@@ -503,8 +504,8 @@ NOTE: if you're using cert-manager, backup any necessary secrets to avoid being 
 
 ## TODO
 * ~~`wait-for` startup ordering for `keycloak` <- `oauth2-proxy` + `apiserver` (OIDC discovery)~~
-* ~~Verbose configuration documentation~~
-* ~~Adjust webui to speak `_oauth2_proxy` instead of / addition in speaking `keycloak` for OIDC~~
 * source chart somewhere.. NCSA Harbor? github pages?
+* Verbose configuration documentation
+* Adjust webui to speak `_oauth2_proxy` instead of / addition in speaking `keycloak` for OIDC
 * MongoDB replication
 * Git release workflows? CI? Github Actions?

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -87,17 +87,24 @@ spec:
 {{ toYaml . | indent 10 }}
 {{- end }}
         ports:
+{{- if .Values.config.frontend.live_reload }}
+        - containerPort: 3000
+          name: webui
+{{- else }}
         - containerPort: 80
           name: webui
+{{- end }}
         volumeMounts:
-        - name: frontend-config
-          mountPath: /usr/share/nginx/html/frontend.json
-          subPath: frontend.json
 {{- with .Values.controller.extraVolumeMounts.webui }}
 {{ toYaml . | indent 8 }}
 {{- end }}
-{{- with .Values.resources.webui }}
+{{- if not .Values.config.frontend.live_reload }}
+        - name: frontend-config
+          mountPath: /usr/share/nginx/html/frontend.json
+          subPath: frontend.json
+{{- end }}
         resources:
+{{- with .Values.resources.webui }}
 {{ toYaml . | indent 10 }}
 {{- end }}
 

--- a/values.localdev.livereload.yaml
+++ b/values.localdev.livereload.yaml
@@ -1,0 +1,42 @@
+
+
+# Expose mongodb on port 30017 for local development (insecure!)
+mongodb:
+  service:
+    type: NodePort
+    nodePorts:
+      mongodb: 30017
+
+config:
+  frontend:
+    live_reload: true
+
+controller:
+  images:
+    # use dev image (also enable config.frontend.live_reload)
+    webui: "ndslabs/webui:develop-live"
+
+  # Enable DEBUG mode for Python API (auto-restart when source updates)
+  extraEnv:
+    apiserver:
+    - name: DEBUG
+      value: "true"
+
+  # Override frontend mountPath (default: /usr/share/nginx/html/)
+  extraVolumeMounts:
+    webui:
+    - mountPath: /app/                            # for live_reload
+      name: webuisrc
+    apiserver:
+    - mountPath: /app/
+      name: apisrc
+
+  # Create volumes from the source code on the host machine
+  extraVolumes:
+    - name: webuisrc
+      hostPath:
+        path: /Users/lambert8/workspace/national-data-service/workbench-helm-chart/src/webui/         # for live_reload
+    - name: apisrc
+      hostPath:
+        path: /Users/lambert8/workspace/national-data-service/workbench-helm-chart/src/apiserver
+

--- a/values.localdev.yaml
+++ b/values.localdev.yaml
@@ -10,36 +10,6 @@ extraDeploy: []
 
 controller:
   strategy_type: "RollingUpdate"  # default: RollingUpdate
-
-  extraEnv:
-    # Enable DEBUG mode for Python API (auto-restart when source updates)
-    apiserver:
-    - name: DEBUG
-      value: "true"
-
-  extraVolumeMounts:
-    # Mount WebUI build output into running container - this requires an IDE or running `make compile`
-    webui:
-    - mountPath: /usr/share/nginx/html/
-      name: webuisrc
-
-    # Mount Python API source code into running container
-    apiserver:
-    - mountPath: /app/
-      name: apisrc
-
-  # Create volumes from the source code on the host machine
-  extraVolumes:
-    # Mount WebUI build output into running container - this requires an IDE or running `make compile`
-    - name: webuisrc
-      hostPath:
-        path: /Users/lambert8/workspace/national-data-service/workbench-helm-chart/src/webui/build
-
-    # Mount Python API source code into running container
-    - name: apisrc
-      hostPath:
-        path: /Users/lambert8/workspace/national-data-service/workbench-helm-chart/src/apiserver
-
   serviceAccount:
     create: false
   images:
@@ -58,6 +28,7 @@ ingress:
 
 config:
   frontend:
+    live_reload: false
     support_email: "support@ndslabs.org"
     domain: "https://kubernetes.docker.internal"
     analytics_tracking_id: ""
@@ -80,6 +51,8 @@ config:
     # Define our own domain and config params
     domain: "kubernetes.docker.internal"
     insecure_ssl_verify: "false"   # default: true
+    swagger_url: openapi/swagger-v1.yml
+    namespace: "workbench"
 
 
     # Define parameters about the created userapp

--- a/values.yaml
+++ b/values.yaml
@@ -54,6 +54,7 @@ ingress:
 
 config:
   frontend:
+    live_reload: false
     support_email: ""
     analytics_tracking_id: ""
     signin_url: "https://kubernetes.docker.internal/oauth2/start?rd=https%3A%2F%2Fkubernetes.docker.internal%2Fmy-apps"


### PR DESCRIPTION
## Problem
We may need this after all :)

`make local` does not recompile the webui source without running `make compile` every time..

Since `make compile` runs the prod build, this takes 30+ seconds for every change (compared the `make dev` development build which is nearly instantaneous)

## Approach
Reverts nds-org/workbench-helm-chart#37
