### PR TITLE
fix: remove keycloak import from localdev

### DIFF
--- a/values.localdev.yaml
+++ b/values.localdev.yaml
@@ -120,22 +120,6 @@ keycloak:
     adminUser: "admin"
     adminPassword: "workbench"
   proxyAddressForwarding: true
-  # To automatically import a Keycloak realm for development, uncomment this and create a new configmap:
-  #   kubectl create configmap keycloak-realm -n workbench --from-file=realm.json
-  extraEnvVars:
-    - name: KEYCLOAK_EXTRA_ARGS
-      value: "-Dkeycloak.import=/config/realm.json"
-  extraVolumeMounts:
-    - name: config
-      mountPath: "/config"
-      readOnly: true
-  extraVolumes:
-    - name: config
-      configMap:
-        name: keycloak-realm
-        items:
-        - key: "realm.json"
-          path: "realm.json"
   global:
     storageClass: "hostpath"
   ingress:


### PR DESCRIPTION
## Problem
Unneeded defaults set in `values.localdev.yaml` - there is a section about Keycloak import that should be deleted now that we have a separate file for this.

## Approach
* Remove leftover remnants of keycloak import in localdev - it has already been split into its own file: `values.realmimport.json`