### PR TITLE
fix: replace longhorn StorageClass with cinder-csi-sc-retain

### DIFF
--- a/values.radiant.yaml
+++ b/values.radiant.yaml
@@ -57,7 +57,7 @@ config:
 mongodb:
   enabled: true
   global:
-    storageClass: "longhorn"
+    storageClass: "csi-cinder-sc-retain"
   updateStrategy:
     type: Recreate
   auth:
@@ -82,7 +82,7 @@ keycloak:
 
 oauth2-proxy:
   global:
-    storageClass: "longhorn"
+    storageClass: "csi-cinder-sc-retain"
   ingress:
     hostname: changeme.ndslabs.org
     tls:


### PR DESCRIPTION
## Problem
Longhorn is no longer preferred on Radiant

## Approach
Replace uses of `longhorn` with `cinder-csi-sc-retain` - this will use OpenStack's Cinder CSI plugin instead