### PR TITLE
fix: adjust default helm hooks

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -255,7 +255,7 @@ mongodb:
   autoimport:
     enabled: true
     annotations:
-      "helm.sh/hook": post-install
+      "helm.sh/hook": "post-install,post-upgrade"
       "helm.sh/hook-delete-policy": before-hook-creation
     env:
       - name: MONGO_URI


### PR DESCRIPTION
## Problem
By default, helm would only run `autoimport` on `post-upgrade`

This fails if the user runs `helm install` , but does not run `helm upgrade --install`

## Approach
Add additional hook trigger to support both cases