### PR TITLE
feat: add extraRules config for ingress values

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,10 @@ These options affect the Ingress resources created by this chart.
 | `ingress.host` | string | Host name to use for Ingress resources | `""` |
 | `ingress.tls` | array[map] | TLS config to set for Ingress resources | `[]` |
 | `ingress.tls.hosts` | array[string] | Host names to set for TLS on Ingress resource | `[]` |
-| `ingress.api.annotations` | map | Annotations to set for `api` Ingress resources | `{}` |
-| `ingress.webui.annotations` | map | Annotations to set for `webui` Ingress resources | `{}` |
+| `ingress.api.annotations` | map | Annotations to set for `api` Ingress resource | `{}` |
+| `ingress.api.extraRules` | array | List of additional ingress rules for `api` Ingress resource | `[]` |
+| `ingress.webui.annotations` | map | Annotations to set for `webui` Ingress resource | `{}` |
+| `ingress.webui.extraRules` | array | Lisst of additional ingress rules for `webui` Ingress resource | `[]` |
 
 ### Workbench Options
 These options affect the internals of Workbench and the customization of the WebUI.

--- a/templates/ingress.api.yaml
+++ b/templates/ingress.api.yaml
@@ -29,3 +29,6 @@ spec:
             name: {{ .Release.Name }}
             port: 
               number: 5000
+{{ with .Values.ingress.api.extraRules }}
+  {{ toYaml . | nindent 2 }}
+{{ end }}

--- a/templates/ingress.webui.yaml
+++ b/templates/ingress.webui.yaml
@@ -29,3 +29,6 @@ spec:
             name: {{ .Release.Name }}
             port:
               number: 80
+{{ with .Values.ingress.webui.extraRules }}
+  {{ toYaml . | nindent 2 }}
+{{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -47,9 +47,11 @@ ingress:
     - hosts:
       - "kubernetes.docker.internal"
   api:
+    extraRules: []
     annotations: {}
       #cert-manager.io/issuer: "acmedns-staging"
   webui:
+    extraRules: []
     annotations: {}
 
 


### PR DESCRIPTION
## Problem
Some documentation for workbench/cheesehub still uses (for example) `www.hub.cheesehub.org` instead of `hub.cheesehub.org`

Current Helm chart config is not adequate for correcting the path of users who find these stale links

This should have worked by just setting `annotations` to the following, but that apparently did nothing without a rule set for the `www`-prefixed hostname:
```yaml
ingress:
  webui:
    annotations:
      traefik.ingress.kubernetes.io/preserve-host: "true"
      traefik.ingress.kubernetes.io/redirect-permanent: "true"
      traefik.ingress.kubernetes.io/redirect-regex: "^https://www.(.*)"
      traefik.ingress.kubernetes.io/redirect-replacement: "https://$1"
```

## Approach
Add `extraRules` config, to allow us to add new rules for an individual instance.

This was needed to support the above case in CHEESEHub production.

Landing page (and entire webui) is served on both `www.hub.cheesehub.org` and `hub.cheesehub.org`
After login, user is redirected to `hub.cheesehub.org`, which is where the webapp expects to be running

Production configuration:
```yaml
ingress:
  api:
    annotations:
      cert-manager.io/cluster-issuer: "acmedns-issuer"
  webui:
    # Temporary? Redirect from www.hub to hub
    extraRules:
      - host: www.hub.cheesehub.org
        http:
          paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: cheesehub
                port:
                  number: 80
  host: "hub.cheesehub.org"
  class: ""
  tls:
    - hosts:
      - "hub.cheesehub.org"
      - "*.hub.cheesehub.org"
      secretName: ndslabs-tls
```