### PR TITLE
Use the nfs-subdir-external-provisioner char

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ certs/
 acmedns*.json
 charts/
 src/
+Chart.lock

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,10 +15,10 @@ dependencies:
     version: ~4.1.4
     repository: "https://kubernetes.github.io/ingress-nginx"
     condition: ingress-nginx.enabled
-  - name: nfs-client-provisioner
-    version: ~1.2.11
-    repository: "https://supertetelman.github.io/charts/"
-    condition: nfs-client-provisioner.enabled
+  - name: nfs-subdir-external-provisioner
+    version: ~4.0.17
+    repository: "https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/"
+    condition: nfs-subdir-external-provisioner.enabled
   - name: nfs-server-provisioner
     version: ~1.4.0
     repository: "https://kubernetes-sigs.github.io/nfs-ganesha-server-and-external-provisioner/"

--- a/values.yaml
+++ b/values.yaml
@@ -161,7 +161,7 @@ ingress-nginx:
 
 
 # Enable this to use an external NFS server to provision user volumes (e.g. nfs-condo)
-nfs-client-provisioner:
+nfs-subdir-external-provisioner:
   enabled: false   # WARNING: experimental
   nfs:
     server: "workbench-nfs-server-provisioner.workbench.svc.cluster.local"


### PR DESCRIPTION
Use the nfs-subdir-external-provisioner chart instead of the nfs-client-provisioner chart. The nfs-client-provisioner chart has been depercated.