### PR TITLE
Reduce automated SmokeTest frequency

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,9 +1,9 @@
 name: Smoke Test
 
 on: 
-  # Run once a week at 6AM CST
+  # Run once a month on the first of the month
   schedule:
-    - cron:  '0 12 1/7 * *'
+    - cron:  '0 0 1 * *'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Problem
Workflow is set to run once a day - this is likely way too frequent

## Approach 
* fix: adjust schedule to run the workflow once a month, instead of once a day

## How to Test
Wait until the first of the month, when smoke test should next run automatically