### PR TITLE
chore: switch bitnami usage to point at their archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ certs/
 acmedns*.json
 charts/
 src/
-Chart.lock

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,0 +1,21 @@
+dependencies:
+- name: oauth2-proxy
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+  version: 3.1.0
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 4.1.4
+- name: nfs-subdir-external-provisioner
+  repository: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
+  version: 4.0.18
+- name: nfs-server-provisioner
+  repository: https://kubernetes-sigs.github.io/nfs-ganesha-server-and-external-provisioner/
+  version: 1.4.0
+- name: mongodb
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+  version: 13.0.2
+- name: keycloak
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+  version: 9.6.9
+digest: sha256:9ca436433f84c25522594e450cbe2ccc81885a68a535eb37711ad27c1b73db09
+generated: "2026-02-13T16:50:31.698037-06:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -10,7 +10,7 @@ version: 1.4.0
 dependencies:
   - name: oauth2-proxy
     version: ~3.1.0
-    repository: "https://charts.bitnami.com/bitnami"
+    repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
   - name: ingress-nginx
     version: ~4.1.4
     repository: "https://kubernetes.github.io/ingress-nginx"
@@ -25,9 +25,9 @@ dependencies:
     condition: nfs-server-provisioner.enabled
   - name: mongodb
     version: ~13.0.1
-    repository: "https://charts.bitnami.com/bitnami"
+    repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
     condition: mongodb.enabled
   - name: keycloak
     version: ~9.6.9
-    repository: "https://charts.bitnami.com/bitnami"
+    repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
     condition: keycloak.enabled

--- a/values.yaml
+++ b/values.yaml
@@ -236,6 +236,10 @@ oauth2-proxy:
   image:
     registry: docker.io
     repository: bitnamilegacy/oauth2-proxy
+  redis:
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/redis
   initContainers: []
   extraArgs:
     # Github OIDC config:

--- a/values.yaml
+++ b/values.yaml
@@ -182,6 +182,9 @@ nfs-server-provisioner:
 # Enable this to run a local Keycloak instance (development only)
 keycloak:
   enabled: false
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/keycloak
   httpRelativePath: "/auth/"
   auth:
     adminUser: "admin"
@@ -211,6 +214,9 @@ keycloak:
         password: workbench
   postgresql:
     enabled: true
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/postgresql
   service:
     type: ClusterIP
   ingress:
@@ -227,6 +233,9 @@ keycloak:
 
 
 oauth2-proxy:
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/oauth2-proxy
   initContainers: []
   extraArgs:
     # Github OIDC config:
@@ -254,6 +263,9 @@ oauth2-proxy:
 
 mongodb:
   enabled: true
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/mongodb
   autoimport:
     enabled: true
     annotations:


### PR DESCRIPTION
## Problem
Bitnami Helm charts are gone, but we still need some small pieces from their ashes

## Approach
* fix: pin to bitnami archive on github

We should also consider including / updating `Chart.lock` here, but this file is not typically edited by hand and instead should be updated by running `helm dep up`