### PR TITLE
chore: localdev - switch to MongoDB Kubernetes Operator

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -128,7 +128,7 @@ jobs:
           kubectl get pods,pvc -n workbench
           kubectl get mdbc workbench-mongodb -n workbench
           kubectl describe mdbc workbench-mongodb -n workbench
-          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl -vvv --fail --insecure http://localhost:5000/api/v1/services || kubectl logs -f -lapp.kubernetes.io/component=workbench -n ${NAMESPACE} -c apiserver && exit 500
+          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl -vvv --fail --insecure http://localhost:5000/api/v1/services || kubectl logs -f -lapp.kubernetes.io/component=workbench -n workbench -c apiserver && exit 500
 
       - name: "Test Connection - Ingress -> WebUI"
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -128,7 +128,7 @@ jobs:
           kubectl get pods,pvc -n workbench
           kubectl get mdbc workbench-mongodb -n workbench
           kubectl describe mdbc workbench-mongodb -n workbench
-          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl -vvv --fail --insecure http://localhost:5000/api/v1/services || kubectl logs -f -lapp.kubernetes.io/component=workbench -n workbench -c apiserver && exit 500
+          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl -vvv --fail --insecure http://localhost:5000/api/v1/services || kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c apiserver && exit 500
 
       - name: "Test Connection - Ingress -> WebUI"
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -128,7 +128,7 @@ jobs:
           kubectl get pods,pvc -n workbench
           kubectl get mdbc workbench-mongodb -n workbench
           kubectl describe mdbc workbench-mongodb -n workbench
-          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl -vvv --fail --insecure http://localhost:5000/api/v1/services
+          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl -vvv --fail --insecure http://localhost:5000/api/v1/services || kubectl logs -f -lapp.kubernetes.io/component=workbench -n ${NAMESPACE} -c apiserver && exit 500
 
       - name: "Test Connection - Ingress -> WebUI"
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -124,7 +124,7 @@ jobs:
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=workbench --for condition=Ready --timeout 10s
           kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout 10s
           sleep 2
-          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl --fail --insecure https://workbench-ingress-nginx-controller.workbench.svc.cluster.local/api/v1/services
+          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl --fail --insecure http://localhost:5000/api/v1/services
 
       - name: "Test Connection - Ingress -> WebUI"
         run: |
@@ -228,7 +228,7 @@ jobs:
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=workbench --for condition=Ready --timeout 10s
           kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout 10s
           sleep 2
-          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl --fail --insecure https://workbench-ingress-nginx-controller.workbench.svc.cluster.local/api/v1/services
+          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl --fail --insecure http://localhost:5000/api/v1/services
 
       - name: "Test Connection - Ingress -> WebUI"
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -125,7 +125,8 @@ jobs:
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=workbench --for condition=Ready --timeout 10s
           kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout 10s
           sleep 2
-          kubectl get pods,mdbc,pvc workbench-mongodb -n workbench
+          kubectl get pods,pvc -n workbench
+          kubectl get mdbc workbench-mongodb -n workbench
           kubectl describe mdbc workbench-mongodb -n workbench
           kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl -vvv --fail --insecure http://localhost:5000/api/v1/services
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Wait for MongoDB + Workbench to start
         run: |
-          kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout=90s || kubectl describe pod -lapp.kubernetes.io/component=mongodb -n workbench && kubectl logs -lapp=workbench-mongodb-svc -n workbench -c mongod
+          kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout=90s || kubectl describe pod -lapp=workbench-mongodb-svc -n workbench && kubectl logs -lapp=workbench-mongodb-svc -n workbench -c mongod
           kubectl get pods -n workbench
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=workbench --for condition=Ready --timeout=300s || kubectl describe pod -lapp.kubernetes.io/component=workbench -n workbench && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c wait-for-oauth2-proxy && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c webui && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c apiserver
           kubectl get pods -n workbench
@@ -122,7 +122,7 @@ jobs:
         run: |
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=controller --for condition=Ready --timeout 15s
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=workbench --for condition=Ready --timeout 10s
-          kubectl wait pods -n workbench -lapp.kubernetes.io/component=mongodb --for condition=Ready --timeout 10s
+          kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout 10s
           sleep 2
           kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl --fail --insecure https://workbench-ingress-nginx-controller.workbench.svc.cluster.local/api/v1/services
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Wait for MongoDB + Workbench to start
         run: |
-          kubectl wait pods -n workbench -lapp.kubernetes.io/component=mongodb --for condition=Ready --timeout=90s || kubectl describe pod -lapp.kubernetes.io/component=mongodb -n workbench && kubectl logs -lapp.kubernetes.io/component=mongodb -n workbench
+          kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout=90s || kubectl describe pod -lapp.kubernetes.io/component=mongodb -n workbench && kubectl logs -lapp=workbench-mongodb-svc -n workbench
           kubectl get pods -n workbench
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=workbench --for condition=Ready --timeout=300s || kubectl describe pod -lapp.kubernetes.io/component=workbench -n workbench && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c wait-for-oauth2-proxy && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c webui && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c apiserver
           kubectl get pods -n workbench
@@ -203,7 +203,7 @@ jobs:
 
       - name: Wait for MongoDB + Workbench to start
         run: |
-          kubectl wait pods -n workbench -lapp.kubernetes.io/component=mongodb --for condition=Ready --timeout=90s || kubectl describe pod -lapp.kubernetes.io/component=mongodb -n workbench && kubectl logs -lapp.kubernetes.io/component=mongodb -n workbench
+          kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout=90s || kubectl describe pod -lapp=workbench-mongodb-svc -n workbench && kubectl logs -lapp=workbench-mongodb-svc -n workbench
           kubectl get pods -n workbench
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=workbench --for condition=Ready --timeout=300s || kubectl describe pod -lapp.kubernetes.io/component=workbench -n workbench && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c wait-for-oauth2-proxy && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c webui && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c apiserver
           kubectl get pods -n workbench
@@ -226,7 +226,7 @@ jobs:
         run: |
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=controller --for condition=Ready --timeout 15s
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=workbench --for condition=Ready --timeout 10s
-          kubectl wait pods -n workbench -lapp.kubernetes.io/component=mongodb --for condition=Ready --timeout 10s
+          kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout 10s
           sleep 2
           kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl --fail --insecure https://workbench-ingress-nginx-controller.workbench.svc.cluster.local/api/v1/services
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Wait for MongoDB + Workbench to start
         run: |
-          kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout=90s || kubectl describe pod -lapp.kubernetes.io/component=mongodb -n workbench && kubectl logs -lapp=workbench-mongodb-svc -n workbench mongod
+          kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout=90s || kubectl describe pod -lapp.kubernetes.io/component=mongodb -n workbench && kubectl logs -lapp=workbench-mongodb-svc -n workbench -c mongod
           kubectl get pods -n workbench
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=workbench --for condition=Ready --timeout=300s || kubectl describe pod -lapp.kubernetes.io/component=workbench -n workbench && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c wait-for-oauth2-proxy && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c webui && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c apiserver
           kubectl get pods -n workbench

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -109,14 +109,14 @@ jobs:
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=controller --for condition=Ready --timeout 10s
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=oauth2-proxy --for condition=Ready --timeout 10s
           sleep 2
-          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl --insecure https://workbench-ingress-nginx-controller.workbench.svc.cluster.local/oauth2/auth
+          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl --insecure https://workbench-ingress-nginx-controller.workbench.svc.cluster.local/oauth2/auth || kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c apiserver
 
       - name: "Test Connection - Ingress -> Workbench API"
         run: |
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=controller --for condition=Ready --timeout 10s
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=workbench --for condition=Ready --timeout 10s
           sleep 2
-          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl --fail --insecure https://workbench-ingress-nginx-controller.workbench.svc.cluster.local/api/v1/version
+          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl --fail --insecure https://workbench-ingress-nginx-controller.workbench.svc.cluster.local/api/v1/version || kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c apiserver
 
       - name: "Test Connection - Workbench API -> MongoDB"
         run: |
@@ -128,7 +128,7 @@ jobs:
           kubectl get pods,pvc -n workbench
           kubectl get mdbc workbench-mongodb -n workbench
           kubectl describe mdbc workbench-mongodb -n workbench
-          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl -vvv --fail --insecure http://localhost:5000/api/v1/services || kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c apiserver && exit 500
+          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl --fail --insecure http://localhost:5000/api/v1/services || kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c apiserver
 
       - name: "Test Connection - Ingress -> WebUI"
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Wait for MongoDB + Workbench to start
         run: |
-          kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout=90s || kubectl describe pod -lapp.kubernetes.io/component=mongodb -n workbench && kubectl logs -lapp=workbench-mongodb-svc -n workbench
+          kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout=90s || kubectl describe pod -lapp.kubernetes.io/component=mongodb -n workbench && kubectl logs -lapp=workbench-mongodb-svc -n workbench mongod
           kubectl get pods -n workbench
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=workbench --for condition=Ready --timeout=300s || kubectl describe pod -lapp.kubernetes.io/component=workbench -n workbench && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c wait-for-oauth2-proxy && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c webui && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c apiserver
           kubectl get pods -n workbench
@@ -203,7 +203,7 @@ jobs:
 
       - name: Wait for MongoDB + Workbench to start
         run: |
-          kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout=90s || kubectl describe pod -lapp=workbench-mongodb-svc -n workbench && kubectl logs -lapp=workbench-mongodb-svc -n workbench
+          kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout=90s || kubectl describe pod -lapp=workbench-mongodb-svc -n workbench && kubectl logs -lapp=workbench-mongodb-svc -n workbench -c mongod
           kubectl get pods -n workbench
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=workbench --for condition=Ready --timeout=300s || kubectl describe pod -lapp.kubernetes.io/component=workbench -n workbench && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c wait-for-oauth2-proxy && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c webui && kubectl logs -lapp.kubernetes.io/component=workbench -n workbench -c apiserver
           kubectl get pods -n workbench

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -120,6 +120,7 @@ jobs:
 
       - name: "Test Connection - Workbench API -> MongoDB"
         run: |
+          kubectl wait mdbc workbench-mongodb -n workbench --for=jsonpath='{.status.phase}'=Running --timeout 300s
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=controller --for condition=Ready --timeout 15s
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=workbench --for condition=Ready --timeout 10s
           kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout 10s
@@ -224,6 +225,7 @@ jobs:
 
       - name: "Test Connection - Workbench API -> MongoDB"
         run: |
+          kubectl wait mdbc workbench-mongodb -n workbench --for=jsonpath='{.status.phase}'=Running --timeout 300s
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=controller --for condition=Ready --timeout 15s
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=workbench --for condition=Ready --timeout 10s
           kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout 10s

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -125,7 +125,9 @@ jobs:
           kubectl wait pods -n workbench -lapp.kubernetes.io/component=workbench --for condition=Ready --timeout 10s
           kubectl wait pods -n workbench -lapp=workbench-mongodb-svc --for condition=Ready --timeout 10s
           sleep 2
-          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl --fail --insecure http://localhost:5000/api/v1/services
+          kubectl get pods,mdbc,pvc workbench-mongodb -n workbench
+          kubectl describe mdbc workbench-mongodb -n workbench
+          kubectl exec -it deploy/workbench -c apiserver -n workbench -- curl -vvv --fail --insecure http://localhost:5000/api/v1/services
 
       - name: "Test Connection - Ingress -> WebUI"
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ certs/
 acmedns*.json
 charts/
 src/
-Chart.lock

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,0 +1,21 @@
+dependencies:
+- name: oauth2-proxy
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+  version: 3.1.0
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 4.1.4
+- name: nfs-subdir-external-provisioner
+  repository: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
+  version: 4.0.18
+- name: nfs-server-provisioner
+  repository: https://kubernetes-sigs.github.io/nfs-ganesha-server-and-external-provisioner/
+  version: 1.4.0
+- name: mongodb
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+  version: 13.0.2
+- name: keycloak
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+  version: 9.6.9
+digest: sha256:9ca436433f84c25522594e450cbe2ccc81885a68a535eb37711ad27c1b73db09
+generated: "2026-02-13T16:50:31.698037-06:00"

--- a/Chart.lock
+++ b/Chart.lock
@@ -8,17 +8,14 @@ dependencies:
 - name: nfs-subdir-external-provisioner
   repository: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
   version: 4.0.18
-- name: mongodb-kubernetes
-  repository: https://mongodb.github.io/helm-charts
-  version: 1.5.0
 - name: nfs-server-provisioner
   repository: https://kubernetes-sigs.github.io/nfs-ganesha-server-and-external-provisioner/
   version: 1.8.0
-- name: mongodb
-  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
-  version: 13.0.2
+- name: mongodb-kubernetes
+  repository: https://mongodb.github.io/helm-charts
+  version: 1.5.0
 - name: keycloak
   repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 9.6.9
-digest: sha256:8b4b6590fac2b7e7978fde2e1f92e8bff333324fcbc2b9956423e75dc2888b88
-generated: "2026-02-16T07:01:51.821948-06:00"
+digest: sha256:f33481139f673c85867f8bd07561cb02ee4cdc753f28f53612a59db754f93bb7
+generated: "2026-02-16T14:54:36.096426-06:00"

--- a/Chart.lock
+++ b/Chart.lock
@@ -8,14 +8,14 @@ dependencies:
 - name: nfs-subdir-external-provisioner
   repository: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
   version: 4.0.18
+- name: mongodb-kubernetes
+  repository: https://mongodb.github.io/helm-charts
+  version: 1.5.0
 - name: nfs-server-provisioner
   repository: https://kubernetes-sigs.github.io/nfs-ganesha-server-and-external-provisioner/
-  version: 1.4.0
-- name: mongodb
-  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
-  version: 13.0.2
+  version: 1.8.0
 - name: keycloak
   repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 9.6.9
-digest: sha256:9ca436433f84c25522594e450cbe2ccc81885a68a535eb37711ad27c1b73db09
-generated: "2026-02-13T16:50:31.698037-06:00"
+digest: sha256:2bb573581e88b9ec1772b8896266d0e7515ad2ff397b46b82e10be36a95f579d
+generated: "2026-02-16T05:38:39.355406-06:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -19,14 +19,14 @@ dependencies:
     version: ~4.0.17
     repository: "https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/"
     condition: nfs-subdir-external-provisioner.enabled
+  - name: mongodb-kubernetes
+    version: 1.5.0
+    repository: "https://mongodb.github.io/helm-charts"
+    condition: mongodb.enabled
   - name: nfs-server-provisioner
-    version: ~1.4.0
+    version: ~1.8.0
     repository: "https://kubernetes-sigs.github.io/nfs-ganesha-server-and-external-provisioner/"
     condition: nfs-server-provisioner.enabled
-  - name: mongodb
-    version: ~13.0.1
-    repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
-    condition: mongodb.enabled
   - name: keycloak
     version: ~9.6.9
     repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -19,17 +19,13 @@ dependencies:
     version: ~4.0.17
     repository: "https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/"
     condition: nfs-subdir-external-provisioner.enabled
-  - name: mongodb-kubernetes
-    version: 1.5.0
-    repository: "https://mongodb.github.io/helm-charts"
-    condition: mongodb.enabled
   - name: nfs-server-provisioner
     version: ~1.8.0
     repository: "https://kubernetes-sigs.github.io/nfs-ganesha-server-and-external-provisioner/"
     condition: nfs-server-provisioner.enabled
-  - name: mongodb
-    version: ~13.0.1
-    repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
+  - name: mongodb-kubernetes
+    version: 1.5.0
+    repository: "https://mongodb.github.io/helm-charts"
     condition: mongodb.enabled
   - name: keycloak
     version: ~9.6.9

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -10,7 +10,7 @@ version: 1.4.0
 dependencies:
   - name: oauth2-proxy
     version: ~3.1.0
-    repository: "https://charts.bitnami.com/bitnami"
+    repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
   - name: ingress-nginx
     version: ~4.1.4
     repository: "https://kubernetes.github.io/ingress-nginx"
@@ -25,9 +25,9 @@ dependencies:
     condition: nfs-server-provisioner.enabled
   - name: mongodb
     version: ~13.0.1
-    repository: "https://charts.bitnami.com/bitnami"
+    repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
     condition: mongodb.enabled
   - name: keycloak
     version: ~9.6.9
-    repository: "https://charts.bitnami.com/bitnami"
+    repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
     condition: keycloak.enabled

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ logs: check_kubectl
 	if [ "$(target)" == "" ]; then echo 'Please specify a target: api (apiserver), ui (webui), proxy (oauth2-proxy), db (mongo, mongodb), kc (keycloak), nginx (ingress)'; echo 'Example usage: "make target=apiserver logs"'; fi
 	if [ "$(target)" == "api" -o "$(target)" == "apiserver" ]; then kubectl logs -f -lapp.kubernetes.io/instance=$(NAME),app.kubernetes.io/name=$(NAME) -n $(NAMESPACE) -c apiserver; fi
 	if [ "$(target)" == "ui" -o "$(target)" == "webui" ]; then kubectl logs -f -lapp.kubernetes.io/instance=$(NAME),app.kubernetes.io/name=$(NAME) -n $(NAMESPACE) -c webui; fi
-	if [ "$(target)" == "db" -o "$(target)" == "mongo" -o "$(target)" == "mongodb" ]; then kubectl logs -f -lapp.kubernetes.io/instance=$(NAME),app.kubernetes.io/name=mongodb; fi
+	if [ "$(target)" == "db" -o "$(target)" == "mongo" -o "$(target)" == "mongodb" ]; then kubectl logs -f -lapp=workbench-mongodb-svc -n $(NAMESPACE); fi
 	if [ "$(target)" == "kc" -o "$(target)" == "keycloak" ]; then kubectl logs -f -lapp.kubernetes.io/instance=$(NAME),app.kubernetes.io/name=keycloak -n $(NAMESPACE); fi
 	if [ "$(target)" == "nginx" -o "$(target)" == "ingress" ]; then kubectl logs -f -lapp.kubernetes.io/instance=$(NAME),app.kubernetes.io/name=ingress-nginx -n $(NAMESPACE); fi
 	if [ "$(target)" == "proxy" -o "$(target)" == "oauth2-proxy" ]; then kubectl logs -f -lapp.kubernetes.io/instance=$(NAME),app.kubernetes.io/name=oauth2-proxy -n $(NAMESPACE); fi

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ acmedns_secret: check_kubectl
 	kubectl create secret generic acme-dns -n $(NAMESPACE) --from-file=acmedns.json
 
 status: check_kubectl
-	kubectl get pods,pvc -n $(NAMESPACE)
+	kubectl get pods,mdbc,pvc -n $(NAMESPACE)
 
 watch: check_kubectl
 	kubectl get pods -n $(NAMESPACE) -w

--- a/values.ci.yaml
+++ b/values.ci.yaml
@@ -145,7 +145,7 @@ mongodb:
       - name: FORCE
         value: "true"
       - name: MONGO_URI
-        value: "mongodb://workbench:workbench@workbench-mongodb.workbench.svc.cluster.local:27017/ndslabs?authSource=admin"
+        value: "mongodb://workbench:workbench@workbench-mongodb-svc.workbench.svc.cluster.local:27017/ndslabs?authSource=admin"
       - name: GIT_REPO
         value: "https://github.com/nds-org/ndslabs-specs"
       - name: GIT_BRANCH

--- a/values.localdev.yaml
+++ b/values.localdev.yaml
@@ -6,7 +6,56 @@
 
 
 
-extraDeploy: []
+extraDeploy:
+- apiVersion: mongodbcommunity.mongodb.com/v1
+  kind: MongoDBCommunity
+  metadata:
+    name: workbench-mongodb
+  spec:
+    members: 1
+    type: ReplicaSet
+    version: "6.0.5"
+    security:
+      authentication:
+        modes: ["SCRAM"]
+    users:
+      - name: workbench
+        db: admin
+        passwordSecretRef: # a reference to the secret that will be used to generate the user's password
+          name: workbench-password
+        roles:
+          - name: clusterAdmin
+            db: admin
+          - name: userAdminAnyDatabase
+            db: admin
+          - db: admin
+            name: backup
+          - db: admin
+            name: restore
+          - db: admin
+            name: dbOwner
+          - name: userAdminAnyDatabase
+            db: ndslabs
+          - db: ndslabs
+            name: backup
+          - db: ndslabs
+            name: restore
+          - db: ndslabs
+            name: dbOwner
+        scramCredentialsSecretName: workbench-password
+    additionalMongodConfig:
+      storage.wiredTiger.engineConfig.journalCompressor: zlib
+
+# the user credentials will be generated from this secret
+# once the credentials are generated, this secret is no longer required
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: workbench-password
+  type: Opaque
+  stringData:
+    password: workbench
+  
 
 controller:
   strategy_type: "RollingUpdate"  # default: RollingUpdate
@@ -38,7 +87,7 @@ config:
   backend:
     # Point at internal mongodb
     mongo:
-      uri: "mongodb://workbench:workbench@workbench-mongodb.workbench.svc.cluster.local:27017/ndslabs?authSource=admin"
+      uri: "mongodb://workbench:workbench@workbench-mongodb-svc.workbench.svc.cluster.local:27017/ndslabs?authSource=admin"
       db: ndslabs
 
     # Point at internal Keycloak instance + imported realm
@@ -59,7 +108,7 @@ config:
     userapps:
       home_storage:
         enabled: true
-        storage_class: nfs
+        storage_class: ""
       shared_storage:
         enabled: false
       ingress:
@@ -191,7 +240,7 @@ mongodb:
       - name: FORCE
         value: "true"
       - name: MONGO_URI
-        value: "mongodb://workbench:workbench@workbench-mongodb.workbench.svc.cluster.local:27017/ndslabs?authSource=admin"
+        value: "mongodb://workbench:workbench@workbench-mongodb-svc.workbench.svc.cluster.local:27017/ndslabs?authSource=admin"
       - name: GIT_REPO
         value: "https://github.com/nds-org/ndslabs-specs"
       - name: GIT_BRANCH

--- a/values.localdev.yaml
+++ b/values.localdev.yaml
@@ -108,7 +108,7 @@ config:
     userapps:
       home_storage:
         enabled: true
-        storage_class: ""
+        storage_class: nfs
       shared_storage:
         enabled: false
       ingress:

--- a/values.yaml
+++ b/values.yaml
@@ -236,6 +236,10 @@ oauth2-proxy:
   image:
     registry: docker.io
     repository: bitnamilegacy/oauth2-proxy
+  redis:
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/redis
   initContainers: []
   extraArgs:
     # Github OIDC config:

--- a/values.yaml
+++ b/values.yaml
@@ -269,7 +269,9 @@ mongodb:
   enabled: true
   image:
     registry: docker.io
-    repository: bitnamilegacy/mongodb
+#    repository: bitnamilegacy/mongodb
+    repository: mongo
+    tag: latest
   autoimport:
     enabled: true
     annotations:
@@ -288,7 +290,7 @@ mongodb:
   #replicaCount: 3
   auth:
     rootUser: workbench
-    rootPassword: changeme
+    rootPassword: workbench
 
   # TODO: Test AWS + GKE PVs
   persistent:

--- a/values.yaml
+++ b/values.yaml
@@ -99,7 +99,7 @@ config:
 
     # Point at internal mongodb
     mongo:
-      uri: "mongodb://workbench:workbench@workbench-mongodb.workbench.svc.cluster.local:27017/ndslabs?authSource=admin"
+      uri: "mongodb://workbench:workbench@workbench-mongodb-svc.workbench.svc.cluster.local:27017/ndslabs?authSource=admin"
       db: ndslabs
 
     # Point at internal Keycloak instance + imported realm
@@ -279,7 +279,7 @@ mongodb:
       "helm.sh/hook-delete-policy": before-hook-creation
     env:
       - name: MONGO_URI
-        value: "mongodb://workbench:workbench@workbench-mongodb.workbench.svc.cluster.local:27017/ndslabs?authSource=admin"
+        value: "mongodb://workbench:workbench@workbench-mongodb-svc.workbench.svc.cluster.local:27017/ndslabs?authSource=admin"
       - name: MONGO_DB
         value: "ndslabs"
       - name: GIT_REPO

--- a/values.yaml
+++ b/values.yaml
@@ -182,6 +182,9 @@ nfs-server-provisioner:
 # Enable this to run a local Keycloak instance (development only)
 keycloak:
   enabled: false
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/keycloak
   httpRelativePath: "/auth/"
   auth:
     adminUser: "admin"
@@ -211,6 +214,9 @@ keycloak:
         password: workbench
   postgresql:
     enabled: true
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/postgresql
   service:
     type: ClusterIP
   ingress:
@@ -227,6 +233,9 @@ keycloak:
 
 
 oauth2-proxy:
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/oauth2-proxy
   initContainers: []
   extraArgs:
     # Github OIDC config:
@@ -254,6 +263,9 @@ oauth2-proxy:
 
 mongodb:
   enabled: true
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/mongodb
   autoimport:
     enabled: true
     annotations:


### PR DESCRIPTION
## Problem
* chosen image tag for `nfs-server-provisioner` no longer exists - need to update to a newer version
* chosen dnsmasq image does not support arm64 - need to find a working replacement + config for wildcard DNS
* bitnami registry is no longer a free resource
* bitnami images do not support arm64 (Apple Silicon)
* MongoDB is needed for our application, but currently uses a bitnami Docker image
* We need a local test harness to play around with, but this amd64 image will not run cross platform

We have already updated our docker autobuilds for the [apiserver](https://github.com/nds-org/workbench-apiserver-python/blob/develop/.github/workflows/docker.yml#L75) and [webui](https://github.com/nds-org/workbench-webui/blob/develop/.github/workflows/docker.yml#L73) to produce arm64 images, but we still need a solution for MongoDB

## Approach
* chore: replace references to `bitnami/mongodb` with [MongoDB Kubernetes Operator](https://github.com/mongodb/mongodb-kubernetes/tree/master/docs/mongodbcommunity)

## How to Test
#### Prerequisites (requires Docker Desktop)
* Deploy a local Kubernetes cluster using `kubeadm` or `kind`
    * For macOS or Windows, simply enable Kubernetes in the Settings of Docker Desktop :+1: easy!
    * For Linux where Docker Desktop isn't an option, you can use `kind` to deploy single node cluster for testing: `kind create cluster --config .kind.with.hostpath.yml`
* ~~dnsmasq for wildcard DNS resolution locally (`docker compose -f dnsmasq.compose.yml up -d`)~~ needs more testing
    * alternatively, you can manipulate `/etc/hosts` to emulate this behavior for small-scale testing:
```hosts
# One entry for your root domain
127.0.0.1 kubernetes.docker.internal
# One entry for each workbench app/service that you need to access, for example:
127.0.0.1 testlocalhost-s72299-toolmanager.kubernetes.docker.internal
```

#### Install + Startup (requires Kubernetes cluster + Volume Provisioner)
1. Checkout this branch locally, remove any existing local Workbench instance: `make clean_all`
2. Bring up Workbench: `make dev`
    * You should see the following steps are performed:
        * Helm repos are updated + dependency Helm charts are fetched
        * Backend + Frontend source code is cloned locally, if it is not already present
        * Frontend source code is bundled up via `yarn`
        * Source code / built bundles are mounted into running containers, allowing for live development (though there may be a slight delay for frontend to re-compile after each change - see container logs for details)
        * MongoDB is deployed and a `workbench:workbench` user is created for the `ndslabs` database
        * Keycloak + PostgreSQL are deployed for user management, `workbench-dev` Realm is created automatically
        * OAuth2 Proxy + Redis are deployed, connected to Keycloak
        * NGINX Ingress Controller is deployed (but this may eventually be replaced with Traefik, see #48)
        * Backend is deployed, connected to MongoDB + OAuth2 Proxy + Kubernetes API 
        * Frontend is deployed, connected to Backend + OAuth2 Proxy
3. Wait for all pieces of the application to be Running or Completed: `make status`

#### Signup + Login (requires Keycloak + OAuth2 Proxy)
1. Navigate to https://kubernetes.docker.internal to access the Workbench WebUI
2. Click Log In
    * You should be brought to the Keycloak login screen
3. At the bottom, click "Register"
    * You should be brought to the new user signup form
4. Fill out the form to create a new local test user on the `workbench-dev` realm. For example:
    * First Name: `Test`
    * Last Name: `User`
    * Username: `test`
    * Email: `test@localhost`
    * Password: `asdf1234`
    * Confirm Password: `asdf1234`
5. Submit the form to sign into the Workbench as this user
    * You should be brought to an empty applications dashboard
    * You should see your test email appear at the top-right
    * You should see a prompt linking you to the catalog to add an application

#### AppSpecs + UserApps (requires DNS manipulation)
1. Click on the "All Apps" link to access the catalog
    * You should see many applications are listed in the catalog - these are called **AppSpecs**
    * You should see that the first application listed in the catalog is the "Analysis Toolbox" - this is our simplest test application
2. Click the (+) button to add an instance on the "Analysis Toolbox" app 
    * You should be brought back to the application dashboard, but you should now see your own personal copy of this application is listed here - these are called **UserApps**
    * You should see a Launch button (rocket icon) for this app
3. Click the Launch button
    * You should see the application display turns yellow and indicates that it is working in the background
    * You should see a new Pod now appears via `make status`
4. Wait for the application to finish launching (it shouldn't take longer than ~1 minute)
    * you should see the application display turns green and indicates that it now offers a clickable link - this allows you to access the running application